### PR TITLE
✨ feat(xbot): update submodule and add bind address parameter to Io a…

### DIFF
--- a/portable/xbot/Io.cpp
+++ b/portable/xbot/Io.cpp
@@ -1,6 +1,7 @@
 //
 // Created by clemens on 7/14/24.
 //
+#include <string.h>
 #include <ulog.h>
 
 #include <xbot-service/Io.hpp>
@@ -99,7 +100,8 @@ bool Io::getEndpoint(char* ip, size_t ip_len, uint16_t* port) {
   return sock::getEndpoint(&udp_socket_, ip, ip_len, port);
 }
 
-bool Io::start() {
+bool Io::start(const char* bind_ip) {
+  chDbgAssert(strcmp(bind_ip, "0.0.0.0") == 0, "bind_ip not supported on this platform");
   if (!sock::initialize(&udp_socket_, false)) {
     return false;
   }

--- a/portable/xbot/socket.cpp
+++ b/portable/xbot/socket.cpp
@@ -15,8 +15,9 @@
 using namespace xbot::service::sock;
 using namespace xbot::service::packet;
 
-bool xbot::service::sock::initialize(SocketPtr socket_ptr, bool bind_multicast) {
+bool xbot::service::sock::initialize(SocketPtr socket_ptr, bool bind_multicast, const char* bind_address) {
   chDbgAssert(!bind_multicast, "Multicast is not supported on the MAC implementation");
+  chDbgAssert(strcmp(bind_address, "0.0.0.0") == 0, "bind_address not supported on this platform");
   *socket_ptr = -1;
   // Create a UDP socket
 


### PR DESCRIPTION
…nd socket initialization

- update xbot_framework submodule to new commit 4f23159b
- add `#include <string.h>` to Io.cpp for strcmp function
- modify Io::start() to accept a `bind_ip` parameter and assert it equals "0.0.0.0"
- modify sock::initialize() to accept a `bind_address` parameter and assert it equals "0.0.0.0"