### PR TITLE
Proper Charger/BMS implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         src/filesystem/filesystem.cpp
         src/services/imu_service/imu_service.cpp
         src/services/power_service/power_service.cpp
+        src/services/bms_service/bms_service.cpp
         src/services/emergency_service/emergency_service.cpp
         src/services/diff_drive_service/diff_drive_service.cpp
         src/services/mower_service/mower_service.cpp
@@ -159,6 +160,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
 
 target_add_service(${CMAKE_PROJECT_NAME} ImuService ${CMAKE_CURRENT_SOURCE_DIR}/services/imu_service.json)
 target_add_service(${CMAKE_PROJECT_NAME} PowerService ${CMAKE_CURRENT_SOURCE_DIR}/services/power_service.json)
+target_add_service(${CMAKE_PROJECT_NAME} BmsService ${CMAKE_CURRENT_SOURCE_DIR}/services/bms_service.json)
 target_add_service(${CMAKE_PROJECT_NAME} EmergencyService ${CMAKE_CURRENT_SOURCE_DIR}/services/emergency_service.json)
 target_add_service(${CMAKE_PROJECT_NAME} DiffDriveService ${CMAKE_CURRENT_SOURCE_DIR}/services/diff_drive_service.json)
 target_add_service(${CMAKE_PROJECT_NAME} MowerService ${CMAKE_CURRENT_SOURCE_DIR}/services/mower_service.json)

--- a/portable/xbot/Io.cpp
+++ b/portable/xbot/Io.cpp
@@ -1,6 +1,7 @@
 //
 // Created by clemens on 7/14/24.
 //
+#include <string.h>
 #include <ulog.h>
 
 #include <xbot-service/Io.hpp>
@@ -99,7 +100,8 @@ bool Io::getEndpoint(char* ip, size_t ip_len, uint16_t* port) {
   return sock::getEndpoint(&udp_socket_, ip, ip_len, port);
 }
 
-bool Io::start() {
+bool Io::start(const char* bind_ip) {
+  chDbgAssert(strcmp(bind_ip, "0.0.0.0") == 0, "bind_ip not supported on this platform");
   if (!sock::initialize(&udp_socket_, false)) {
     return false;
   }

--- a/portable/xbot/socket.cpp
+++ b/portable/xbot/socket.cpp
@@ -15,8 +15,9 @@
 using namespace xbot::service::sock;
 using namespace xbot::service::packet;
 
-bool xbot::service::sock::initialize(SocketPtr socket_ptr, bool bind_multicast) {
+bool xbot::service::sock::initialize(SocketPtr socket_ptr, bool bind_multicast, const char* bind_address) {
   chDbgAssert(!bind_multicast, "Multicast is not supported on the MAC implementation");
+  chDbgAssert(strcmp(bind_address, "0.0.0.0") == 0, "bind_address not supported on this platform");
   *socket_ptr = -1;
   // Create a UDP socket
 

--- a/robots/include/lyfco_e1600_robot.hpp
+++ b/robots/include/lyfco_e1600_robot.hpp
@@ -28,7 +28,7 @@ class Lyfco_E1600Robot : public MowerRobot {
   }
 
  private:
-  BQ2576 charger_{};
+  BQ2576 charger_{249000, 14040};  // FIXME: Assumed Universal Board
 };
 
 #endif  // LYFCO_E1600_ROBOT_HPP

--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -42,6 +42,30 @@ class Robot {
   virtual float Power_GetDefaultChargeCurrent() = 0;
 
   /**
+   * Return the charge voltage target (VREG) in Volts.
+   * Returns 0 to leave the hardware-pin configured voltage unchanged.
+   */
+  virtual float Power_GetDefaultChargeVoltage() {
+    return 0.0f;
+  }
+
+  /**
+   * Return the termination current (ITERM) in Amps.
+   * Charging is considered done when CV current drops below this value.
+   */
+  virtual float Power_GetDefaultTerminationCurrent() {
+    return 0.250f;
+  }
+
+  /**
+   * Return the pre-charge current (IPRECHG) in Amps.
+   * Used when VBAT < VBAT_LOWV (pre-charge region).
+   */
+  virtual float Power_GetDefaultPreChargeCurrent() {
+    return 0.250f;
+  }
+
+  /**
    * Return the minimum voltage before shutting down as much as possible
    */
   virtual float Power_GetAbsoluteMinVoltage() = 0;

--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -4,6 +4,7 @@
 #include <drivers/motor/vesc/VescDriver.h>
 #include <drivers/motor/yfr4esc/YFR4escDriver.h>
 #include <hal.h>
+#include <service_ids.h>
 
 #include <debug/debug_tcp_interface.hpp>
 #include <limits>
@@ -17,8 +18,7 @@ class Robot {
   virtual bool IsHardwareSupported() = 0;
 
   virtual bool NeedsService(uint16_t id) {
-    (void)id;
-    return true;
+    return id != xbot::service_ids::BMS;  // BMS is opt-in, all other services are required by default
   }
 
   virtual UARTDriver* GPS_GetUartPort() {

--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -77,7 +77,7 @@ class Robot {
 
   /**
    * Set the max. allowed system current in Amps.
-   * This is to limit e.g. the charger current for not overloading the power supply.
+   * This is to limit e.g. the charger current for not overloading the wall power supply.
    * Only usefull for systems that do have some kind of system current sense.
    */
   virtual void Power_SetSystemCurrent(float system_current) {

--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -7,6 +7,7 @@
 #include <service_ids.h>
 
 #include <debug/debug_tcp_interface.hpp>
+#include <drivers/charger/charger.hpp>
 #include <limits>
 
 // Forward declare ProtocolType from GpsServiceBase.hpp
@@ -63,6 +64,10 @@ class Robot {
    */
   virtual float Power_GetDefaultPreChargeCurrent() {
     return 0.250f;
+  }
+
+  virtual ChargerDriver::ReChargeVoltage Power_GetDefaultReChargeVoltage() {
+    return ChargerDriver::ReChargeVoltage::PERCENT_97_6;
   }
 
   /**

--- a/robots/include/sabo_robot.hpp
+++ b/robots/include/sabo_robot.hpp
@@ -35,25 +35,40 @@ class SaboRobot : public MowerRobot {
     return &UARTD6;
   }
 
+  float Power_GetDefaultChargeVoltage() override {
+    // This is not recommended for older (10+ year) cells like ours and should only be used for new packs
+    // return 7.0f * 4.2f;  // = 29.4V
+    // For older cells, we should not expect the full capacity and also not overstress them
+    return 7.0f * 4.15f;  // = 29.05V. You may lower via powerservice register for more aged packs
+  }
+
   float Power_GetDefaultBatteryFullVoltage() override {
-    return 29.0f;  // Conservative. Rated on battery pack is 29.4V
+    return Power_GetDefaultChargeVoltage() * 0.9f;
   }
 
   float Power_GetDefaultBatteryEmptyVoltage() override {
-    return 7.0f * 3.36f;  // 23.52V
+    return 7.0f * 3.5f;  // 24.5V
   }
 
   float Power_GetAbsoluteMinVoltage() override {
     // Stock Sabo battery pack has INR18650-13L (Samsung) which are specified as:
-    // Empty = 3.0V, Critical discharge <=2.5V. For now, let's stay save and use 3.15V,
+    // Empty = 3.0V, Critical discharge <=2.5V. For now, let's stay save,
     // because most packages are > 10 years old now and cells may be a bit worn out.
-    return 7.0f * 3.2;  // 22.4V
+    return 7.0f * 3.45f;  // 24.15V
   }
 
   float Power_GetDefaultChargeCurrent() override {
     // Battery pack is 7S3P, so max. would be 1.3Ah * 3 = 3.9A
     // 3.9A would be also approx. the max. charge current for the stock 90W PSU!
     return 2.5f;  // Lets stay save and conservative for now
+  }
+
+  float Power_GetDefaultTerminationCurrent() override {
+    return 0.3f;  // 300mA
+  }
+
+  float Power_GetDefaultPreChargeCurrent() override {
+    return 0.5f;  // 500mA
   }
 
   bool SaveGpsSettings(ProtocolType protocol, uint8_t uart, uint32_t baudrate) override;
@@ -128,7 +143,9 @@ class SaboRobot : public MowerRobot {
   bool HasInvertedHallSensors() const;
 
  private:
-  BQ2576 charger_{0.005f};  // All Sabo's do have an 5mΩ Rac_sns
+  // r_top=249k, r_bot=13.7k per Sabo schematic
+  // Power_GetDefaultChargeVoltage() fine-tunes to 29.4V via VFB_REG on each init.
+  BQ2576 charger_{249000, 13700, 0.005f};  // All Sabo's do have an 5mΩ Rac_sns
   SaboCoverUIController cover_ui_{hardware_config};
   SaboInputDriver sabo_input_driver_{hardware_config};
   SaboBmsDriver bms_{hardware_config.bms};

--- a/robots/include/sabo_robot.hpp
+++ b/robots/include/sabo_robot.hpp
@@ -151,6 +151,11 @@ class SaboRobot : public MowerRobot {
     }
   }
 
+  // Charger driver access for direct hardware readings
+  BQ2576& GetCharger() {
+    return charger_;
+  }
+
   bool HasInvertedHallSensors() const;
 
  private:

--- a/robots/include/sabo_robot.hpp
+++ b/robots/include/sabo_robot.hpp
@@ -42,10 +42,10 @@ class SaboRobot : public MowerRobot {
   }
 
   float Power_GetDefaultChargeVoltage() override {
-    // This is not recommended for older (10+ year) cells like ours and should only be used for new packs
+    // This is not recommended for older (10+ year) cells like ours and should only be used for fresh packs
     // return 7.0f * 4.2f;  // = 29.4V
     // For older cells, we should not expect the full capacity and also not overstress them
-    return 7.0f * 4.15f;  // = 29.05V. You may lower via powerservice register for more aged packs
+    return 7.0f * 4.157f;  // = ~29.1V. You may lower via powerservice register for more aged packs
   }
 
   float Power_GetDefaultBatteryFullVoltage() override {
@@ -75,6 +75,11 @@ class SaboRobot : public MowerRobot {
 
   float Power_GetDefaultPreChargeCurrent() override {
     return 0.5f;  // 500mA
+  }
+
+  ChargerDriver::ReChargeVoltage Power_GetDefaultReChargeVoltage() override {
+    // Sabo batteries are mostly around 10 years old. Be nice to them for a longer life.
+    return ChargerDriver::ReChargeVoltage::PERCENT_95_2;
   }
 
   bool SaveGpsSettings(ProtocolType protocol, uint8_t uart, uint32_t baudrate) override;

--- a/robots/include/sabo_robot.hpp
+++ b/robots/include/sabo_robot.hpp
@@ -9,6 +9,7 @@
 #include <drivers/ui/SaboCoverUI/sabo_cover_ui_controller.hpp>
 #include <globals.hpp>
 
+#include "../services/service_ids.h"
 #include "robot.hpp"
 #include "sabo_common.hpp"
 
@@ -27,6 +28,11 @@ class SaboRobot : public MowerRobot {
 
   void InitPlatform() override;
   bool IsHardwareSupported() override;
+
+  bool NeedsService(uint16_t id) override {
+    if (id == xbot::service_ids::BMS) return hardware_config.bms != nullptr;
+    return Robot::NeedsService(id);
+  }
 
   UARTDriver* GPS_GetUartPort() override {
 #ifndef STM32_UART_USE_USART6

--- a/robots/include/universal_5s_robot.hpp
+++ b/robots/include/universal_5s_robot.hpp
@@ -21,6 +21,14 @@ class Universal5SRobot : public UniversalRobot {
     // 3.3V min, 5s pack
     return 5.0f * 3.0;
   }
+
+ protected:
+  BQ2576* GetCharger() override {
+    return &charger_;
+  }
+
+ private:
+  BQ2576 charger_{249000, 20000};
 };
 
 #endif  // UNIVERSAL_5S_ROBOT_HPP

--- a/robots/include/universal_7s_robot.hpp
+++ b/robots/include/universal_7s_robot.hpp
@@ -21,6 +21,14 @@ class Universal7SRobot : public UniversalRobot {
     // 3.3V min, 7s pack
     return 7.0f * 3.0;
   }
+
+ protected:
+  BQ2576* GetCharger() override {
+    return &charger_;
+  }
+
+ private:
+  BQ2576 charger_{249000, 14040};
 };
 
 #endif  // UNIVERSAL_7S_ROBOT_HPP

--- a/robots/include/universal_robot.hpp
+++ b/robots/include/universal_robot.hpp
@@ -21,8 +21,7 @@ class UniversalRobot : public MowerRobot {
  protected:
   UniversalRobot() = default;  // Intermediate/abstract class
 
- private:
-  BQ2576 charger_{};
+  virtual BQ2576* GetCharger() = 0;
 };
 
 #endif  // UNIVERSAL_ROBOT_HPP

--- a/robots/include/worx_robot.hpp
+++ b/robots/include/worx_robot.hpp
@@ -32,7 +32,7 @@ class WorxRobot : public MowerRobot {
   }
 
  private:
-  BQ2576 charger_{};
+  BQ2576 charger_{249000, 20000};  // FIXME: Assumed Universal Board
   WorxInputDriver worx_driver_{};
 };
 

--- a/robots/include/yardforce_robot.hpp
+++ b/robots/include/yardforce_robot.hpp
@@ -35,7 +35,7 @@ class YardForceRobot : public MowerRobot {
   }
 
  private:
-  BQ2576 charger_{};
+  BQ2576 charger_{249000, 14040};
 };
 
 #endif  // YARDFORCE_ROBOT_HPP

--- a/robots/include/yardforce_v4_robot.hpp
+++ b/robots/include/yardforce_v4_robot.hpp
@@ -35,7 +35,7 @@ class YardForce_V4Robot : public MowerRobot {
   }
 
  private:
-  BQ2576 charger_{};
+  BQ2576 charger_{249000, 14040};
 };
 
 #endif  // YARDFORCE_V4_ROBOT_HPP

--- a/robots/src/sabo_robot.cpp
+++ b/robots/src/sabo_robot.cpp
@@ -16,10 +16,11 @@ SaboRobot::SaboRobot() : hardware_config(GetHardwareConfig(GetHardwareVersion(ca
 void SaboRobot::InitPlatform() {
   InitMotors();
   charger_.setI2C(&I2CD1);
-  bms_.Init();
-
   power_service.SetDriver(&charger_);
-  power_service.SetDriver(&bms_);
+  if (hardware_config.bms != nullptr) {
+    bms_.Init();
+    bms_service.SetDriver(&bms_);
+  }
   input_service.RegisterInputDriver("sabo", &sabo_input_driver_);
 
   if (hardware_config.adc != nullptr) {

--- a/robots/src/universal_robot.cpp
+++ b/robots/src/universal_robot.cpp
@@ -4,8 +4,8 @@
 
 void UniversalRobot::InitPlatform() {
   InitMotors();
-  charger_.setI2C(&I2CD1);
-  power_service.SetDriver(&charger_);
+  GetCharger()->setI2C(&I2CD1);
+  power_service.SetDriver(GetCharger());
 }
 
 bool UniversalRobot::IsHardwareSupported() {

--- a/src/drivers/bms/sabo_bms_driver.cpp
+++ b/src/drivers/bms/sabo_bms_driver.cpp
@@ -106,7 +106,6 @@ bool SaboBmsDriver::Init() {
 
 void SaboBmsDriver::Tick() {
   static uint8_t check_cnt = 100;  // Need some retries to detect presence
-  static systime_t last_log_time = 0;
 
   if (!configured_ || (!IsPresent() && !check_cnt)) return;
 
@@ -206,25 +205,27 @@ void SaboBmsDriver::Tick() {
 
   // BatteryStatus (0x16) word
   // "FSM-BMZ, 30710, V2.00" seem to support only some of the status bits.
-  if (ReadRegister(0x16, u16) == MSG_OK) {
+  if (ReadRegister(0x16, battery_status_) == MSG_OK) {
     // Bit 11, 0x0800 looks like a TERMINATE_DISCHARGE_ALARM flag, SoC < 5% ?
-    (u16 & 0b0000100000000000)
+    (battery_status_ & 0b0000100000000000)
         ? SbsProtocol::SetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::AlarmTerminateDischarge)
         : SbsProtocol::ResetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::AlarmTerminateDischarge);
     // Bit 7-6 looks like a CHARGING flag => /DISCHARGING
-    ((u16 & 0b11000000) && data_.pack_current_a > 0.0f)
+    ((battery_status_ & 0b11000000) && data_.pack_current_a > 0.0f)
         ? SbsProtocol::ResetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusDischarging)
         : SbsProtocol::SetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusDischarging);
-    // Bit 5 looks like a /FULLY_CHARGED flag
-    (u16 & 0b00100000)
-        ? SbsProtocol::ResetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusFullyCharged)
-        : SbsProtocol::SetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusFullyCharged);
+    // Bit 5: CHARGE_ACCEPTED_N (active-low) — CLEAR = charger accepted, SET = charger absent/rejected.
+    // Map to StatusFullyCharged only when charger is actually accepted AND SOC confirms full.
+    const bool charge_accepted = !(battery_status_ & (1 << 5));
+    (charge_accepted && data_.battery_soc >= 0.99f)
+        ? SbsProtocol::SetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusFullyCharged)
+        : SbsProtocol::ResetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusFullyCharged);
     // Bit 1 looks like a FULLY_DISCHARGED flag, SoC < 20% ?
-    (u16 & 0b00000010)
+    (battery_status_ & 0b00000010)
         ? SbsProtocol::SetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusFullyDischarged)
         : SbsProtocol::ResetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::StatusFullyDischarged);
     // Bit 0 looks like a TERMINATE_DISCHARGE_ALARM flag, SoC < 5% ?
-    /*(u16 & 0b00000001)
+    /*(battery_status_ & 0b00000001)
         ? SbsProtocol::SetBatteryStatus(data_.battery_status, SbsProtocol::BatteryStatusBit::AlarmTerminateDischarge)
         : SbsProtocol::ResetBatteryStatus(data_.battery_status,
        SbsProtocol::BatteryStatusBit::AlarmTerminateDischarge);*/
@@ -245,28 +246,10 @@ void SaboBmsDriver::Tick() {
     }
   }
 
-  // Log BMS data every minute for analysis and BatteryStatus monitoring
-  const systime_t now = chVTGetSystemTimeX();
-  if (chVTTimeElapsedSinceX(last_log_time) > TIME_S2I(60)) {
-    last_log_time = now;
-
-    // Format battery_status as hex and binary
-    char status_bin[17];
-    for (int i = 0; i < 16; i++) {
-      status_bin[i] = (data_.battery_status & (1 << (15 - i))) ? '1' : '0';
-    }
-    status_bin[16] = '\0';
-
-    ULOG_INFO("BMS Data: t=%lu V=%.2f I=%.3f T=%.1f SOC=%.1f%% RemCap=%.3fAh FullCap=%.3fAh Status=0x%04X (%s)",
-              (unsigned long)TIME_I2MS(now), (double)data_.pack_voltage_v, (double)data_.pack_current_a,
-              (double)data_.temperature_c, (double)(data_.battery_soc * 100.0f), (double)data_.remaining_capacity_ah,
-              (double)data_.full_charge_capacity_ah, (unsigned)data_.battery_status, status_bin);
-  }
   i2cReleaseBus(bms_cfg_->i2c);
 }
 
 const char* SaboBmsDriver::GetExtraDataJson() const {
-  // FIXME: Quite large JSON buffer. Optimize as streamed output?
   static char json_buf[512];
 
   json_buf[0] = '\0';
@@ -301,6 +284,9 @@ const char* SaboBmsDriver::GetExtraDataJson() const {
                       ",\"full_charge_capacity_ah\":%.3f,\"remaining_capacity_ah\":%.3f,\"cycle_count\":%u",
                       (double)data_.full_charge_capacity_ah, (double)data_.remaining_capacity_ah,
                       (unsigned)data_.cycle_count);
+
+  // Status
+  chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars, ",\"status\":\"%u\"", battery_status_);
 
   // Cell voltages
   chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars, ",\"cell_count\":%u,\"cell_voltage_v\": [",

--- a/src/drivers/bms/sabo_bms_driver.cpp
+++ b/src/drivers/bms/sabo_bms_driver.cpp
@@ -281,7 +281,7 @@ const char* SaboBmsDriver::GetExtraDataJson() const {
                       (unsigned)data_.serial_number, (double)data_.design_capacity_ah, (double)data_.design_voltage_v);
 
   // Status
-  chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars, ",\"status\":\"%u\"", battery_status_);
+  chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars, ",\"status\":%u", battery_status_);
 
   // Cell voltages
   chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars, ",\"cell_count\":%u,\"cell_voltage_v\": [",

--- a/src/drivers/bms/sabo_bms_driver.cpp
+++ b/src/drivers/bms/sabo_bms_driver.cpp
@@ -280,11 +280,6 @@ const char* SaboBmsDriver::GetExtraDataJson() const {
                       ",\"serial_number\":%u,\"design_capacity_ah\":%.3f,\"design_voltage_v\":%.3f",
                       (unsigned)data_.serial_number, (double)data_.design_capacity_ah, (double)data_.design_voltage_v);
 
-  chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars,
-                      ",\"full_charge_capacity_ah\":%.3f,\"remaining_capacity_ah\":%.3f,\"cycle_count\":%u",
-                      (double)data_.full_charge_capacity_ah, (double)data_.remaining_capacity_ah,
-                      (unsigned)data_.cycle_count);
-
   // Status
   chars += chsnprintf(json_buf + chars, sizeof(json_buf) - chars, ",\"status\":\"%u\"", battery_status_);
 

--- a/src/drivers/bms/sabo_bms_driver.hpp
+++ b/src/drivers/bms/sabo_bms_driver.hpp
@@ -59,6 +59,7 @@ class SaboBmsDriver : public BmsDriver {
   const xbot::driver::sabo::config::Bms* bms_cfg_;
 
   SbsProtocol sbs_{};
+  uint16_t battery_status_{0};  // Our BMS is not SBS-compliant, so we like to track the battery status for publishing
 
   bool configured_{false};
   bool probe();

--- a/src/drivers/charger/bq_2576/bq_2576.cpp
+++ b/src/drivers/charger/bq_2576/bq_2576.cpp
@@ -162,6 +162,17 @@ bool BQ2576::readBatteryVoltage(float& result) {
   return true;
 }
 
+bool BQ2576::setChargeVoltage(float voltage_v) {
+  if (vfb_ratio_ <= 0.0f) return false;
+
+  float vfb_mv = voltage_v * 1000.0f * vfb_ratio_;
+  vfb_mv = std::max(1504.0f, std::min(1566.0f, vfb_mv));  // Clamp to 1504mV - 1566mV
+  uint16_t reg_val = static_cast<uint16_t>((vfb_mv - 1504.0f) / 2.0f);
+  reg_val &= 0b11111;  // Mask [4:0]
+
+  return writeRegister16(REG_Charge_Voltage_Limit, reg_val);
+}
+
 bool BQ2576::resetWatchdog() {
   // TODO, if the REG_Charger_Control is used, we need to either store the value
   // or read it here before resetting the watchdog.
@@ -241,6 +252,7 @@ bool BQ2576::setTerminationCurrent(float current_amps) {
   uint16_t value = static_cast<uint16_t>(current_amps * 1000.0f / 50.0f) << 2;
   return writeRegister16(REG_Termination_Current_Limit, value);
 }
+
 CHARGER_STATUS BQ2576::getChargerStatus() {
   uint8_t status1, status2, status3;
   bool s = getChargerStatus(status1, status2, status3);
@@ -260,6 +272,7 @@ CHARGER_STATUS BQ2576::getChargerStatus() {
     case 2: return CHARGER_STATUS::PRE_CHARGE;
     case 3: return CHARGER_STATUS::CC;
     case 4: return CHARGER_STATUS::CV;
+    case 5: return CHARGER_STATUS::UNKNOWN;  // Reserved as per datasheet, not an error
     case 6: return CHARGER_STATUS::TOP_OFF;
     case 7: return CHARGER_STATUS::DONE;
     default: return CHARGER_STATUS::COMMS_ERROR;

--- a/src/drivers/charger/bq_2576/bq_2576.cpp
+++ b/src/drivers/charger/bq_2576/bq_2576.cpp
@@ -176,7 +176,9 @@ bool BQ2576::setChargeVoltage(float voltage_v) {
 bool BQ2576::resetWatchdog() {
   // TODO, if the REG_Charger_Control is used, we need to either store the value
   // or read it here before resetting the watchdog.
-  uint8_t val = 0b11111001;
+  // Tektek test with 94.3% VRECHG
+  // uint8_t val = 0b11111001;
+  uint8_t val = 0b01111001;
   return writeRegister8(REG_Charger_Control, val);
 }
 

--- a/src/drivers/charger/bq_2576/bq_2576.cpp
+++ b/src/drivers/charger/bq_2576/bq_2576.cpp
@@ -162,7 +162,7 @@ bool BQ2576::readBatteryVoltage(float& result) {
   return true;
 }
 
-bool BQ2576::setChargeVoltage(float voltage_v) {
+bool BQ2576::setChargingVoltage(float voltage_v) {
   if (vfb_ratio_ <= 0.0f) return false;
 
   float vfb_mv = voltage_v * 1000.0f * vfb_ratio_;
@@ -177,8 +177,8 @@ bool BQ2576::resetWatchdog() {
   return writeRegister8(REG_Charger_Control, charger_control_reg_ | (1 << 5));  // Set WD_RST
 }
 
-bool BQ2576::setReChargeVoltage(uint8_t recharge_voltage) {
-  charger_control_reg_ = (charger_control_reg_ & 0b00111111) | ((recharge_voltage & 0x03) << 6);
+bool BQ2576::setReChargeVoltage(ReChargeVoltage recharge_voltage) {
+  charger_control_reg_ = (charger_control_reg_ & 0b00111111) | ((static_cast<uint8_t>(recharge_voltage) & 0x03) << 6);
   return writeRegister8(REG_Charger_Control, charger_control_reg_);
 }
 

--- a/src/drivers/charger/bq_2576/bq_2576.cpp
+++ b/src/drivers/charger/bq_2576/bq_2576.cpp
@@ -174,12 +174,12 @@ bool BQ2576::setChargeVoltage(float voltage_v) {
 }
 
 bool BQ2576::resetWatchdog() {
-  // TODO, if the REG_Charger_Control is used, we need to either store the value
-  // or read it here before resetting the watchdog.
-  // Tektek test with 94.3% VRECHG
-  // uint8_t val = 0b11111001;
-  uint8_t val = 0b01111001;
-  return writeRegister8(REG_Charger_Control, val);
+  return writeRegister8(REG_Charger_Control, charger_control_reg_ | (1 << 5));  // Set WD_RST
+}
+
+bool BQ2576::setReChargeVoltage(uint8_t recharge_voltage) {
+  charger_control_reg_ = (charger_control_reg_ & 0b00111111) | ((recharge_voltage & 0x03) << 6);
+  return writeRegister8(REG_Charger_Control, charger_control_reg_);
 }
 
 bool BQ2576::getChargerStatus(uint8_t& status1, uint8_t& status2, uint8_t& status3) {

--- a/src/drivers/charger/bq_2576/bq_2576.hpp
+++ b/src/drivers/charger/bq_2576/bq_2576.hpp
@@ -14,7 +14,15 @@ using CHARGER_STATUS = ChargerDriver::CHARGER_STATUS;
 
 class BQ2576 : public ChargerDriver {
  public:
-  explicit BQ2576(float r_ac_sense = 0.0f) : ChargerDriver(), r_ac_sense_(r_ac_sense) {
+  // Internal FBG pull-down resistor to PGND, typic 33 Ohm (max. 55 Ohm)
+  static constexpr uint32_t INTERNAL_RFBG = 33;
+
+  // r_top: external resistor VBAT->FB (Ohm), r_bot: external resistor FB->FBG (Ohm)
+  // vfb_ratio_ = VFB/VBATREG = (r_bot - RFBG) / (r_bot - RFBG + r_top)
+  explicit BQ2576(uint32_t r_top, uint32_t r_bot, float r_ac_sense = 0.0f)
+      : ChargerDriver(),
+        vfb_ratio_(static_cast<float>(r_bot - INTERNAL_RFBG) / static_cast<float>(r_bot - INTERNAL_RFBG + r_top)),
+        r_ac_sense_(r_ac_sense) {
   }
 
  private:
@@ -45,7 +53,9 @@ class BQ2576 : public ChargerDriver {
   static constexpr uint8_t REG_Gate_Driver_Strength_Control = 0x3B;
   static constexpr uint8_t REG_Precharge_Current_Limit = 0x10;
   static constexpr uint8_t REG_Precharge_and_Termination_Control = 0x14;
+  static constexpr uint8_t REG_Charge_Voltage_Limit = 0x00;
 
+  const float vfb_ratio_;   // VFB/VBATREG
   const float r_ac_sense_;  // 0 = No Rac_sns
 
   bool readRegister(uint8_t reg, uint8_t &result);
@@ -60,6 +70,7 @@ class BQ2576 : public ChargerDriver {
   uint8_t readFaults();
 
  public:
+  bool setChargeVoltage(float voltage_v) override;
   bool setAdapterCurrent(float current_amps) override;
   bool setChargingCurrent(float current_amps, bool overwrite_hardware_limit) override;
   bool setPreChargeCurrent(float current_amps) override;

--- a/src/drivers/charger/bq_2576/bq_2576.hpp
+++ b/src/drivers/charger/bq_2576/bq_2576.hpp
@@ -74,7 +74,7 @@ class BQ2576 : public ChargerDriver {
   uint8_t readFaults();
 
  public:
-  bool setChargeVoltage(float voltage_v) override;
+  bool setChargingVoltage(float voltage_v) override;
   bool setAdapterCurrent(float current_amps) override;
   bool setChargingCurrent(float current_amps, bool overwrite_hardware_limit) override;
   bool setPreChargeCurrent(float current_amps) override;
@@ -84,8 +84,7 @@ class BQ2576 : public ChargerDriver {
   bool init() override;
   bool resetWatchdog() override;
 
-  // VRECHG enum values are 0=93%, 1=94.3%, 2=95.2%, 3=97.6%
-  bool setReChargeVoltage(uint8_t recharge_voltage) override;
+  bool setReChargeVoltage(ReChargeVoltage recharge_voltage) override;
   bool setTsEnabled(bool enabled) override;
 
   bool readAdapterCurrent(float &result) override;

--- a/src/drivers/charger/bq_2576/bq_2576.hpp
+++ b/src/drivers/charger/bq_2576/bq_2576.hpp
@@ -58,6 +58,10 @@ class BQ2576 : public ChargerDriver {
   const float vfb_ratio_;   // VFB/VBATREG
   const float r_ac_sense_;  // 0 = No Rac_sns
 
+  // Charger control (0x17) persistent state
+  // Defaults: VRECHG=95.2%, DIS_CE_PIN=1, EN_CHG_BIT_RESET_BEHAVIOR=1, EN_CHG=1
+  uint8_t charger_control_reg_ = 0b10011001;
+
   bool readRegister(uint8_t reg, uint8_t &result);
   bool readRegister(uint8_t reg, uint16_t &result);
   bool writeRegister8(uint8_t reg, uint8_t value);
@@ -80,6 +84,8 @@ class BQ2576 : public ChargerDriver {
   bool init() override;
   bool resetWatchdog() override;
 
+  // VRECHG enum values are 0=93%, 1=94.3%, 2=95.2%, 3=97.6%
+  bool setReChargeVoltage(uint8_t recharge_voltage) override;
   bool setTsEnabled(bool enabled) override;
 
   bool readAdapterCurrent(float &result) override;

--- a/src/drivers/charger/charger.hpp
+++ b/src/drivers/charger/charger.hpp
@@ -43,6 +43,10 @@ class ChargerDriver {
                 "CHARGER_STATUS_STRINGS size must match CHARGER_STATUS enum count");
 
   virtual ~ChargerDriver() = default;
+  virtual bool setChargeVoltage(float voltage_v) {
+    (void)voltage_v;
+    return false;
+  }
   virtual bool setAdapterCurrent(float current_amps) = 0;
   virtual bool setChargingCurrent(float current_amps, bool overwrite_hardware_limit) = 0;
   virtual bool setPreChargeCurrent(float current_amps) = 0;

--- a/src/drivers/charger/charger.hpp
+++ b/src/drivers/charger/charger.hpp
@@ -55,6 +55,13 @@ class ChargerDriver {
   virtual bool init() = 0;
   virtual bool resetWatchdog() = 0;
   virtual bool setTsEnabled(bool enabled) = 0;
+
+  // VRECHG enum values are 0=93%, 1=94.3%, 2=95.2%, 3=97.6%
+  virtual bool setReChargeVoltage(uint8_t recharge_voltage) {
+    (void)recharge_voltage;
+    return false;
+  }
+
   virtual bool readChargeCurrent(float &result) = 0;
   virtual bool readAdapterVoltage(float &result) = 0;
   virtual bool readAdapterCurrent(float &result) = 0;

--- a/src/drivers/charger/charger.hpp
+++ b/src/drivers/charger/charger.hpp
@@ -42,13 +42,15 @@ class ChargerDriver {
                     static_cast<size_t>(CHARGER_STATUS::UNKNOWN) + 1,
                 "CHARGER_STATUS_STRINGS size must match CHARGER_STATUS enum count");
 
+  enum class ReChargeVoltage : uint8_t { PERCENT_93_0 = 0, PERCENT_94_3 = 1, PERCENT_95_2 = 2, PERCENT_97_6 = 3 };
+
   virtual ~ChargerDriver() = default;
-  virtual bool setChargeVoltage(float voltage_v) {
-    (void)voltage_v;
-    return false;
-  }
   virtual bool setAdapterCurrent(float current_amps) = 0;
   virtual bool setChargingCurrent(float current_amps, bool overwrite_hardware_limit) = 0;
+  virtual bool setChargingVoltage(float voltage_v) {
+    (void)voltage_v;
+    return true;
+  }
   virtual bool setPreChargeCurrent(float current_amps) = 0;
   virtual bool setTerminationCurrent(float current_amps) = 0;
   virtual CHARGER_STATUS getChargerStatus() = 0;
@@ -56,10 +58,9 @@ class ChargerDriver {
   virtual bool resetWatchdog() = 0;
   virtual bool setTsEnabled(bool enabled) = 0;
 
-  // VRECHG enum values are 0=93%, 1=94.3%, 2=95.2%, 3=97.6%
-  virtual bool setReChargeVoltage(uint8_t recharge_voltage) {
+  virtual bool setReChargeVoltage(ReChargeVoltage recharge_voltage) {
     (void)recharge_voltage;
-    return false;
+    return true;
   }
 
   virtual bool readChargeCurrent(float &result) = 0;

--- a/src/drivers/ui/lvgl/sabo/sabo_screen_main.hpp
+++ b/src/drivers/ui/lvgl/sabo/sabo_screen_main.hpp
@@ -535,12 +535,10 @@ class SaboScreenMain : public ScreenBase<ScreenId, ButtonId> {
 
     if (charger_->readAdapterVoltage(adapter_volts)) {
       adapter_volts = std::round(adapter_volts * 10.0f) / 10.0f;
+      is_docked_ = adapter_volts > 10.0f;
     }
     charger_->readChargeCurrent(charge_current);
     charger_status = charger_->getChargerStatus();
-
-    // Update docked state detection (using adapter voltage)
-    is_docked_ = adapter_volts > 10.0f;
 
     // Update docked state
     icon_docked_->SetState(is_docked_ ? WidgetIcon::State::ON : WidgetIcon::State::OFF);

--- a/src/drivers/ui/lvgl/sabo/sabo_screen_main.hpp
+++ b/src/drivers/ui/lvgl/sabo/sabo_screen_main.hpp
@@ -36,6 +36,7 @@
 #include "../screen_base.hpp"
 #include "../widget_icon.hpp"
 #include "../widget_textbar.hpp"
+#include "drivers/charger/charger.hpp"
 #include "robots/include/sabo_common.hpp"
 #include "robots/include/sabo_robot.hpp"
 #include "services.hpp"
@@ -56,6 +57,7 @@ class SaboScreenMain : public ScreenBase<ScreenId, ButtonId> {
     if (robot != nullptr) {
       sabo_robot_ = static_cast<SaboRobot*>(robot);
       bms_data_ = sabo_robot_->GetBmsData();
+      charger_ = &sabo_robot_->GetCharger();
     }
   }
 
@@ -209,6 +211,7 @@ class SaboScreenMain : public ScreenBase<ScreenId, ButtonId> {
  private:
   SaboRobot* sabo_robot_ = nullptr;
   const xbot::driver::bms::Data* bms_data_ = nullptr;
+  ChargerDriver* charger_ = nullptr;
 
   static constexpr lv_coord_t TOPBAR_HEIGHT = 19;
   static constexpr lv_coord_t STATELABEL_HEIGHT = 23;
@@ -428,10 +431,16 @@ class SaboScreenMain : public ScreenBase<ScreenId, ButtonId> {
     static WidgetIcon::Icon last_battery_icon = WidgetIcon::Icon::BATTERY_FULL;
     static WidgetIcon::State last_battery_state = WidgetIcon::State::ON;
 
-    // Prefer BMS pack voltage over power-service voltage. Reduced precision (0.1V resolution)
-    const float battery_volts = bms_data_ != nullptr && bms_data_->pack_voltage_v > 10.0f
-                                    ? std::round(bms_data_->pack_voltage_v * 10.0f) / 10.0f
-                                    : std::round(power_service.GetBatteryVolts() * 10.0f) / 10.0f;
+    float battery_volts = 0.0f;
+    // Prefer BMS pack voltage, then driver-based charger reading, then power-service
+    if (bms_data_ != nullptr && bms_data_->pack_voltage_v > 2.0f) {
+      battery_volts = std::round(bms_data_->pack_voltage_v * 10.0f) / 10.0f;
+    } else if (charger_ != nullptr) {
+      float charger_batt_volts = 0.0f;
+      if (charger_->readBatteryVoltage(charger_batt_volts)) {
+        battery_volts = std::round(charger_batt_volts * 10.0f) / 10.0f;
+      }
+    }
 
     // Prefer calculated battery percentage over BMS battery_soc (BMS SoC is waste)
     const auto battery_percent = GetPercent(battery_volts, sabo_robot_->Power_GetAbsoluteMinVoltage(),
@@ -489,9 +498,16 @@ class SaboScreenMain : public ScreenBase<ScreenId, ButtonId> {
       return;  // Not docked and, no BMS current available, skip update
     }
 
-    // Get current values with reduced precision (0.1V / 0.01A resolution)
-    const float current = has_bms_current_ ? std::round(bms_data_->pack_current_a * 100.0f) / 100.0f
-                                           : std::round(power_service.GetChargeCurrent() * 100.0f) / 100.0f;
+    float current = 0.0f;
+    // Prefer BMS pack current, then driver-based charger reading
+    if (has_bms_current_) {
+      current = std::round(bms_data_->pack_current_a * 100.0f) / 100.0f;
+    } else if (charger_ != nullptr) {
+      float charger_current = 0.0f;
+      if (charger_->readChargeCurrent(charger_current)) {
+        current = std::round(charger_current * 100.0f) / 100.0f;
+      }
+    }
 
     if (current != last_current) {
       chsnprintf(shared_text_buffer_, SHARED_TEXT_BUFFER_SIZE, "%.2fA", current);
@@ -506,15 +522,24 @@ class SaboScreenMain : public ScreenBase<ScreenId, ButtonId> {
    * @brief Update dock-related widgets (docked state, adapter voltage, charge current, charger status)
    */
   void UpdateDockWidgets() {
-    if (sabo_robot_ == nullptr) return;
+    if (sabo_robot_ == nullptr || charger_ == nullptr) return;
 
     // Static variables for caching and change detection
     static float last_adapter_volts;
     static CHARGER_STATUS last_charger_status = CHARGER_STATUS::UNKNOWN;
 
-    // Get current values with reduced precision (0.1V / 0.01A resolution)
-    const float adapter_volts = std::round(power_service.GetAdapterVolts() * 10.0f) / 10.0f;
-    const CHARGER_STATUS charger_status = power_service.GetChargerStatus();
+    // Get values directly from charger driver
+    float adapter_volts = 0.0f;
+    float charge_current = 0.0f;
+    CHARGER_STATUS charger_status = CHARGER_STATUS::UNKNOWN;
+
+    if (charger_->readAdapterVoltage(adapter_volts)) {
+      adapter_volts = std::round(adapter_volts * 10.0f) / 10.0f;
+    }
+    charger_->readChargeCurrent(charge_current);
+    charger_status = charger_->getChargerStatus();
+
+    // Update docked state detection (using adapter voltage)
     is_docked_ = adapter_volts > 10.0f;
 
     // Update docked state

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -12,6 +12,7 @@ EmergencyService emergency_service{xbot::service_ids::EMERGENCY};
 DiffDriveService diff_drive{xbot::service_ids::DIFF_DRIVE};
 MowerService mower_service{xbot::service_ids::MOWER};
 ImuService imu_service{xbot::service_ids::IMU};
+BmsService bms_service{xbot::service_ids::BMS};
 PowerService power_service{xbot::service_ids::POWER};
 GpsService gps_service{xbot::service_ids::GPS};
 InputService input_service{xbot::service_ids::INPUT};
@@ -32,6 +33,7 @@ void StartServices() {
 #endif
   }
 
+  START_IF_NEEDED(bms_service, BMS)
   START_IF_NEEDED(emergency_service, EMERGENCY)
   START_IF_NEEDED(imu_service, IMU)
   START_IF_NEEDED(power_service, POWER)

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVICES_HPP
 #define SERVICES_HPP
 
+#include "services/bms_service/bms_service.hpp"
 #include "services/diff_drive_service/diff_drive_service.hpp"
 #include "services/emergency_service/emergency_service.hpp"
 #include "services/gps_service/gps_service.hpp"
@@ -14,6 +15,7 @@ extern EmergencyService emergency_service;
 extern DiffDriveService diff_drive;
 extern MowerService mower_service;
 extern ImuService imu_service;
+extern BmsService bms_service;
 extern PowerService power_service;
 extern GpsService gps_service;
 extern InputService input_service;

--- a/src/services/bms_service/bms_service.cpp
+++ b/src/services/bms_service/bms_service.cpp
@@ -1,0 +1,41 @@
+/*
+ * OpenMower V2 Firmware
+ * Part of the OpenMower V2 Firmware (https://github.com/xtech/fw-openmower-v2)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "bms_service.hpp"
+
+#include <cstring>
+
+void BmsService::SetDriver(BmsDriver* bms_driver) {
+  bms_ = bms_driver;
+}
+
+void BmsService::service_tick_() {
+  if (bms_data_ == nullptr) return;
+
+  StartTransaction();
+  SendVoltage(bms_data_->pack_voltage_v);
+  SendCurrent(bms_data_->pack_current_a);
+  SendRelativeStateOfCharge(bms_data_->battery_soc);
+  SendRemainingCapacity(bms_data_->remaining_capacity_ah);
+  SendFullChargeCapacity(bms_data_->full_charge_capacity_ah);
+  SendCycleCount(bms_data_->cycle_count);
+  SendTemperature(bms_data_->temperature_c);
+  SendBatteryStatus(bms_data_->battery_status);
+  if (bms_extra_data_ != nullptr) {
+    SendExtraData(bms_extra_data_, (uint32_t)strlen(bms_extra_data_));
+  }
+  CommitTransaction();
+}
+
+void BmsService::driver_tick_() {
+  if (bms_ == nullptr) return;
+  bms_->Tick();
+  if (bms_->IsPresent()) {
+    bms_data_ = bms_->GetData();
+    bms_extra_data_ = bms_->GetExtraDataJson();
+  }
+}

--- a/src/services/bms_service/bms_service.hpp
+++ b/src/services/bms_service/bms_service.hpp
@@ -1,0 +1,42 @@
+/*
+ * OpenMower V2 Firmware
+ * Part of the OpenMower V2 Firmware (https://github.com/xtech/fw-openmower-v2)
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef BMS_SERVICE_HPP
+#define BMS_SERVICE_HPP
+
+#include <ch.h>
+
+#include <BmsServiceBase.hpp>
+#include <drivers/bms/bms_driver.hpp>
+
+using namespace xbot::service;
+using namespace xbot::driver::bms;
+
+class BmsService : public BmsServiceBase {
+ public:
+  explicit BmsService(uint16_t service_id) : BmsServiceBase(service_id, wa, sizeof(wa)) {
+  }
+
+  void SetDriver(BmsDriver* bms_driver);
+
+ private:
+  void service_tick_();
+  void driver_tick_();
+
+  ServiceSchedule tick_schedule_{*this, 1'000'000,
+                                 XBOT_FUNCTION_FOR_METHOD(BmsService, &BmsService::service_tick_, this)};
+  Schedule driver_schedule_{scheduler_, true, 1'000'000,
+                            XBOT_FUNCTION_FOR_METHOD(BmsService, &BmsService::driver_tick_, this)};
+
+  BmsDriver* bms_ = nullptr;
+  const Data* bms_data_ = nullptr;
+  const char* bms_extra_data_ = nullptr;
+
+  THD_WORKING_AREA(wa, 1000){};
+};
+
+#endif  // BMS_SERVICE_HPP

--- a/src/services/bms_service/bms_service.hpp
+++ b/src/services/bms_service/bms_service.hpp
@@ -35,7 +35,7 @@ class BmsService : public BmsServiceBase {
   BmsDriver* bms_ = nullptr;
   const Data* bms_data_ = nullptr;
   const char* bms_extra_data_ = nullptr;
-  j THD_WORKING_AREA(wa, 768){};
+  THD_WORKING_AREA(wa, 768){};
 };
 
 #endif  // BMS_SERVICE_HPP

--- a/src/services/bms_service/bms_service.hpp
+++ b/src/services/bms_service/bms_service.hpp
@@ -35,8 +35,7 @@ class BmsService : public BmsServiceBase {
   BmsDriver* bms_ = nullptr;
   const Data* bms_data_ = nullptr;
   const char* bms_extra_data_ = nullptr;
-
-  THD_WORKING_AREA(wa, 512){};
+  j THD_WORKING_AREA(wa, 768){};
 };
 
 #endif  // BMS_SERVICE_HPP

--- a/src/services/bms_service/bms_service.hpp
+++ b/src/services/bms_service/bms_service.hpp
@@ -36,7 +36,7 @@ class BmsService : public BmsServiceBase {
   const Data* bms_data_ = nullptr;
   const char* bms_extra_data_ = nullptr;
 
-  THD_WORKING_AREA(wa, 1000){};
+  THD_WORKING_AREA(wa, 512){};
 };
 
 #endif  // BMS_SERVICE_HPP

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -109,13 +109,13 @@ void PowerService::charger_tick() {
     if (charger_->init()) {
       // Set the currents low
       bool success = true;
-      if (PrechargeCurrent.valid && PrechargeCurrent.value > 0) {
-        success &= charger_->setPreChargeCurrent(PrechargeCurrent.value);
+      if (PreA.valid && PreA.value > 0) {
+        success &= charger_->setPreChargeCurrent(PreA.value);
       } else {
         success &= charger_->setPreChargeCurrent(robot->Power_GetDefaultPreChargeCurrent());
       }
-      if (TerminationCurrent.valid && TerminationCurrent.value > 0) {
-        success &= charger_->setTerminationCurrent(TerminationCurrent.value);
+      if (TrmA.valid && TrmA.value > 0) {
+        success &= charger_->setTerminationCurrent(TrmA.value);
       } else {
         success &= charger_->setTerminationCurrent(robot->Power_GetDefaultTerminationCurrent());
       }
@@ -125,8 +125,7 @@ void PowerService::charger_tick() {
         success &= charger_->setChargingCurrent(robot->Power_GetDefaultChargeCurrent(), false);
       }
       {
-        float target_v = (ChargeVoltage.valid && ChargeVoltage.value > 0) ? ChargeVoltage.value
-                                                                          : robot->Power_GetDefaultChargeVoltage();
+        float target_v = (ChgV.valid && ChgV.value > 0) ? ChgV.value : robot->Power_GetDefaultChargeVoltage();
         if (target_v > 0) {
           success &= charger_->setChargeVoltage(target_v);
         }

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -109,12 +109,27 @@ void PowerService::charger_tick() {
     if (charger_->init()) {
       // Set the currents low
       bool success = true;
-      success &= charger_->setPreChargeCurrent(0.250f);
-      success &= charger_->setTerminationCurrent(0.250f);
+      if (PrechargeCurrent.valid && PrechargeCurrent.value > 0) {
+        success &= charger_->setPreChargeCurrent(PrechargeCurrent.value);
+      } else {
+        success &= charger_->setPreChargeCurrent(robot->Power_GetDefaultPreChargeCurrent());
+      }
+      if (TerminationCurrent.valid && TerminationCurrent.value > 0) {
+        success &= charger_->setTerminationCurrent(TerminationCurrent.value);
+      } else {
+        success &= charger_->setTerminationCurrent(robot->Power_GetDefaultTerminationCurrent());
+      }
       if (ChargeCurrent.valid && ChargeCurrent.value > 0) {
         success &= charger_->setChargingCurrent(ChargeCurrent.value, false);
       } else {
         success &= charger_->setChargingCurrent(robot->Power_GetDefaultChargeCurrent(), false);
+      }
+      {
+        float target_v = (ChargeVoltage.valid && ChargeVoltage.value > 0) ? ChargeVoltage.value
+                                                                          : robot->Power_GetDefaultChargeVoltage();
+        if (target_v > 0) {
+          success &= charger_->setChargeVoltage(target_v);
+        }
       }
       // Disable temperature sense, the battery doesnt have it
       success &= charger_->setTsEnabled(false);

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -37,13 +37,13 @@ void PowerService::service_tick_() {
   StartTransaction();
   if (charger_configured_) {
     const char* status_text = ChargerDriver::statusToString(charger_status);
-    SendChargingStatus(status_text, strlen(status_text));
+    SendChargerStatus(status_text, strlen(status_text));
   } else {
-    SendChargingStatus(CHARGE_STATUS_NOT_FOUND_STR, strlen(CHARGE_STATUS_NOT_FOUND_STR));
+    SendChargerStatus(CHARGE_STATUS_NOT_FOUND_STR, strlen(CHARGE_STATUS_NOT_FOUND_STR));
   }
   SendBatteryVoltage(battery_volts);
-  SendChargeVoltage(adapter_volts);
-  SendChargeCurrent(charge_current);
+  SendChargingVoltage(adapter_volts);
+  SendChargingCurrent(charge_current);
   SendChargerEnabled(true);
   if (BatteryFullVoltage.valid && BatteryEmptyVoltage.valid) {
     battery_percent =
@@ -57,7 +57,7 @@ void PowerService::service_tick_() {
 
   // ADC values
   SendBatteryVoltageADC(battery_volts_adc);
-  SendChargeVoltageADC(adapter_volts_adc);
+  SendChargingVoltageADC(adapter_volts_adc);
   SendDCDCInputCurrent(dcdc_current);
 
   CommitTransaction();

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -19,16 +19,12 @@ void PowerService::SetDriver(ChargerDriver* charger_driver) {
   charger_ = charger_driver;
 }
 
-void PowerService::SetDriver(BmsDriver* bms_driver) {
-  bms_ = bms_driver;
-}
-
 bool PowerService::OnStart() {
   charger_configured_ = false;
   return true;
 }
 
-void PowerService::tick() {
+void PowerService::service_tick_() {
   xbot::service::Lock lk{&mtx_};
   // Send the sensor values
   StartTransaction();
@@ -38,11 +34,10 @@ void PowerService::tick() {
   } else {
     SendChargingStatus(CHARGE_STATUS_NOT_FOUND_STR, strlen(CHARGE_STATUS_NOT_FOUND_STR));
   }
-  SendBatteryVoltageCHG(battery_volts);
-  SendChargeVoltageCHG(adapter_volts);
+  SendBatteryVoltage(battery_volts);
+  SendChargeVoltage(adapter_volts);
   SendChargeCurrent(charge_current);
   SendChargerEnabled(true);
-  float battery_percent;
   if (BatteryFullVoltage.valid && BatteryEmptyVoltage.valid) {
     battery_percent =
         (battery_volts - BatteryEmptyVoltage.value) / (BatteryFullVoltage.value - BatteryEmptyVoltage.value);
@@ -53,18 +48,6 @@ void PowerService::tick() {
   SendBatteryPercentage(etl::max(0.0f, etl::min(1.0f, battery_percent)));
   SendChargerInputCurrent(adapter_current);
 
-  // BMS values
-  if (bms_data_ != nullptr) {
-    SendBatteryCurrent(bms_data_->pack_current_a);
-    SendBatteryVoltageBMS(bms_data_->pack_voltage_v);
-    SendBatterySoC(bms_data_->battery_soc);
-    SendBatteryTemperature(bms_data_->temperature_c);
-    SendBatteryStatus(bms_data_->battery_status);
-  }
-  if (bms_extra_data_ != nullptr) {
-    SendBMSExtraData(bms_extra_data_, (uint32_t)strlen(bms_extra_data_));
-  }
-
   // ADC values
   SendBatteryVoltageADC(battery_volts_adc);
   SendChargeVoltageADC(adapter_volts_adc);
@@ -73,32 +56,24 @@ void PowerService::tick() {
   CommitTransaction();
 }
 
-void PowerService::drivers_tick() {
-  charger_tick();
-
-  // Optional BMS tick and data retrieval
-  if (bms_ != nullptr) {
-    bms_->Tick();
-    if (bms_->IsPresent()) {
-      bms_data_ = bms_->GetData();
-      bms_extra_data_ = bms_->GetExtraDataJson();
-    }
-  }
-
-  // ADC readings (for debugging use e.g.: adc1::DumpBenchmarkMeasurement(Adc1ConversionId::V_BATTERY, "V-BAT");
-  {
-    xbot::service::Lock lk{&mtx_};
-    adapter_volts_adc = adc1::GetValueOrNaN(adc1::Adc1ConversionId::V_CHARGER, 100);
-    battery_volts_adc = adc1::GetValueOrNaN(adc1::Adc1ConversionId::V_BATTERY, 100);
-    dcdc_current = adc1::GetValueOrNaN(adc1::Adc1ConversionId::I_IN_DCDC, 100);
-  }
+void PowerService::driver_tick_() {
+  update_charger_();
+  read_adc_();
 
   if (charger_configured_ && power_management_callback_) {
     power_management_callback_();
   }
 }
 
-void PowerService::charger_tick() {
+void PowerService::read_adc_() {
+  // Debugging: adc1::DumpBenchmarkMeasurement(Adc1ConversionId::V_BATTERY, "V-BAT");
+  xbot::service::Lock lk{&mtx_};
+  adapter_volts_adc = adc1::GetValueOrNaN(adc1::Adc1ConversionId::V_CHARGER, 100);
+  battery_volts_adc = adc1::GetValueOrNaN(adc1::Adc1ConversionId::V_BATTERY, 100);
+  dcdc_current = adc1::GetValueOrNaN(adc1::Adc1ConversionId::I_IN_DCDC, 100);
+}
+
+void PowerService::update_charger_() {
   if (charger_ == nullptr) {
     ULOG_ARG_ERROR(&service_id_, "Charger is null!");
     return;
@@ -109,13 +84,13 @@ void PowerService::charger_tick() {
     if (charger_->init()) {
       // Set the currents low
       bool success = true;
-      if (PreA.valid && PreA.value > 0) {
-        success &= charger_->setPreChargeCurrent(PreA.value);
+      if (PreChargeCurrent.valid && PreChargeCurrent.value > 0) {
+        success &= charger_->setPreChargeCurrent(PreChargeCurrent.value);
       } else {
         success &= charger_->setPreChargeCurrent(robot->Power_GetDefaultPreChargeCurrent());
       }
-      if (TrmA.valid && TrmA.value > 0) {
-        success &= charger_->setTerminationCurrent(TrmA.value);
+      if (TerminationCurrent.valid && TerminationCurrent.value > 0) {
+        success &= charger_->setTerminationCurrent(TerminationCurrent.value);
       } else {
         success &= charger_->setTerminationCurrent(robot->Power_GetDefaultTerminationCurrent());
       }
@@ -125,7 +100,8 @@ void PowerService::charger_tick() {
         success &= charger_->setChargingCurrent(robot->Power_GetDefaultChargeCurrent(), false);
       }
       {
-        float target_v = (ChgV.valid && ChgV.value > 0) ? ChgV.value : robot->Power_GetDefaultChargeVoltage();
+        float target_v = (ChargeVoltage.valid && ChargeVoltage.value > 0) ? ChargeVoltage.value
+                                                                          : robot->Power_GetDefaultChargeVoltage();
         if (target_v > 0) {
           success &= charger_->setChargeVoltage(target_v);
         }

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -15,6 +15,12 @@
 
 using namespace xbot::driver;
 
+// Static assertions to ensure ChargerDriver::ReChargeVoltage enum matches PowerService ReChargeVoltages enum
+static_assert(static_cast<uint8_t>(ChargerDriver::ReChargeVoltage::PERCENT_93_0) == 0, "ReChargeVoltage enum mismatch");
+static_assert(static_cast<uint8_t>(ChargerDriver::ReChargeVoltage::PERCENT_94_3) == 1, "ReChargeVoltage enum mismatch");
+static_assert(static_cast<uint8_t>(ChargerDriver::ReChargeVoltage::PERCENT_95_2) == 2, "ReChargeVoltage enum mismatch");
+static_assert(static_cast<uint8_t>(ChargerDriver::ReChargeVoltage::PERCENT_97_6) == 3, "ReChargeVoltage enum mismatch");
+
 void PowerService::SetDriver(ChargerDriver* charger_driver) {
   charger_ = charger_driver;
 }
@@ -22,9 +28,6 @@ void PowerService::SetDriver(ChargerDriver* charger_driver) {
 bool PowerService::OnStart() {
   charger_configured_ = false;
 
-  if (ReChargeVoltage.valid && charger_) {
-    charger_->setReChargeVoltage(static_cast<uint8_t>(ReChargeVoltage.value));
-  }
   return true;
 }
 
@@ -93,23 +96,27 @@ void PowerService::update_charger_() {
       } else {
         success &= charger_->setPreChargeCurrent(robot->Power_GetDefaultPreChargeCurrent());
       }
-      if (TerminationCurrent.valid && TerminationCurrent.value > 0) {
-        success &= charger_->setTerminationCurrent(TerminationCurrent.value);
-      } else {
-        success &= charger_->setTerminationCurrent(robot->Power_GetDefaultTerminationCurrent());
-      }
       if (ChargeCurrent.valid && ChargeCurrent.value > 0) {
         success &= charger_->setChargingCurrent(ChargeCurrent.value, false);
       } else {
         success &= charger_->setChargingCurrent(robot->Power_GetDefaultChargeCurrent(), false);
       }
-      {
-        float target_v = (ChargeVoltage.valid && ChargeVoltage.value > 0) ? ChargeVoltage.value
-                                                                          : robot->Power_GetDefaultChargeVoltage();
-        if (target_v > 0) {
-          success &= charger_->setChargeVoltage(target_v);
-        }
+      if (ChargeVoltage.valid && ChargeVoltage.value > 0) {
+        success &= charger_->setChargingVoltage(ChargeVoltage.value);
+      } else {
+        success &= charger_->setChargingVoltage(robot->Power_GetDefaultChargeVoltage());
       }
+      if (TerminationCurrent.valid && TerminationCurrent.value > 0) {
+        success &= charger_->setTerminationCurrent(TerminationCurrent.value);
+      } else {
+        success &= charger_->setTerminationCurrent(robot->Power_GetDefaultTerminationCurrent());
+      }
+      if (ReChargeVoltage.valid) {
+        success &= charger_->setReChargeVoltage(static_cast<ChargerDriver::ReChargeVoltage>(ReChargeVoltage.value));
+      } else {
+        success &= charger_->setReChargeVoltage(robot->Power_GetDefaultReChargeVoltage());
+      }
+
       // Disable temperature sense, the battery doesn't have it
       success &= charger_->setTsEnabled(false);
       charger_configured_ = success;

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -37,13 +37,13 @@ void PowerService::service_tick_() {
   StartTransaction();
   if (charger_configured_) {
     const char* status_text = ChargerDriver::statusToString(charger_status);
-    SendChargerStatus(status_text, strlen(status_text));
+    SendChargingStatus(status_text, strlen(status_text));
   } else {
-    SendChargerStatus(CHARGE_STATUS_NOT_FOUND_STR, strlen(CHARGE_STATUS_NOT_FOUND_STR));
+    SendChargingStatus(CHARGE_STATUS_NOT_FOUND_STR, strlen(CHARGE_STATUS_NOT_FOUND_STR));
   }
   SendBatteryVoltage(battery_volts);
-  SendChargingVoltage(adapter_volts);
-  SendChargingCurrent(charge_current);
+  SendChargeVoltage(adapter_volts);
+  SendChargeCurrent(charge_current);
   SendChargerEnabled(true);
   if (BatteryFullVoltage.valid && BatteryEmptyVoltage.valid) {
     battery_percent =
@@ -57,7 +57,7 @@ void PowerService::service_tick_() {
 
   // ADC values
   SendBatteryVoltageADC(battery_volts_adc);
-  SendChargingVoltageADC(adapter_volts_adc);
+  SendChargeVoltageADC(adapter_volts_adc);
   SendDCDCInputCurrent(dcdc_current);
 
   CommitTransaction();

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -21,6 +21,10 @@ void PowerService::SetDriver(ChargerDriver* charger_driver) {
 
 bool PowerService::OnStart() {
   charger_configured_ = false;
+
+  if (ReChargeVoltage.valid && charger_) {
+    charger_->setReChargeVoltage(static_cast<uint8_t>(ReChargeVoltage.value));
+  }
   return true;
 }
 
@@ -106,7 +110,7 @@ void PowerService::update_charger_() {
           success &= charger_->setChargeVoltage(target_v);
         }
       }
-      // Disable temperature sense, the battery doesnt have it
+      // Disable temperature sense, the battery doesn't have it
       success &= charger_->setTsEnabled(false);
       charger_configured_ = success;
     }

--- a/src/services/power_service/power_service.hpp
+++ b/src/services/power_service/power_service.hpp
@@ -8,13 +8,11 @@
 #include <ch.h>
 
 #include <PowerServiceBase.hpp>
-#include <drivers/bms/bms_driver.hpp>
 #include <drivers/charger/charger.hpp>
 #include <limits>
 #include <xbot-service/Lock.hpp>
 
 using namespace xbot::service;
-using namespace xbot::driver::bms;
 
 using CHARGER_STATUS = ChargerDriver::CHARGER_STATUS;
 
@@ -24,7 +22,6 @@ class PowerService : public PowerServiceBase {
   }
 
   void SetDriver(ChargerDriver* charger_driver);
-  void SetDriver(BmsDriver* bms_driver);
 
   [[nodiscard]] float GetChargeCurrent() {
     xbot::service::Lock lk{&mtx_};
@@ -92,23 +89,21 @@ class PowerService : public PowerServiceBase {
 
   static constexpr auto CHARGE_STATUS_NOT_FOUND_STR = "Charger Not Found";
 
-  void tick();          // Service tick
-  void drivers_tick();  // Tick for all drivers (i.e charger, BMS, ...)
-  void charger_tick();  // Charger specific tick
+  void service_tick_();
+  void driver_tick_();
+  void update_charger_();
+  void read_adc_();
 
-  ServiceSchedule tick_schedule_{*this, 1'000'000, XBOT_FUNCTION_FOR_METHOD(PowerService, &PowerService::tick, this)};
+  ServiceSchedule tick_schedule_{*this, 1'000'000,
+                                 XBOT_FUNCTION_FOR_METHOD(PowerService, &PowerService::service_tick_, this)};
   Schedule driver_schedule_{scheduler_, true, 1'000'000,
-                            XBOT_FUNCTION_FOR_METHOD(PowerService, &PowerService::drivers_tick, this)};
+                            XBOT_FUNCTION_FOR_METHOD(PowerService, &PowerService::driver_tick_, this)};
 
   bool charger_configured_ = false;
   float charge_current = 0;
   float adapter_volts = 0;
   float battery_volts = 0;
   float battery_percent = 0;
-
-  // BMS data
-  const Data* bms_data_ = nullptr;
-  const char* bms_extra_data_ = nullptr;
 
   // Most designs don't have these
   float adapter_volts_adc = std::numeric_limits<float>::quiet_NaN();
@@ -119,7 +114,6 @@ class PowerService : public PowerServiceBase {
   int critical_count = 0;
   CHARGER_STATUS charger_status = CHARGER_STATUS::COMMS_ERROR;
   ChargerDriver* charger_ = nullptr;
-  BmsDriver* bms_ = nullptr;
 
   PowerManagementCallback power_management_callback_;
 


### PR DESCRIPTION
Proper implementation following the quick-fixes in #42

- [x] Separate BMS from PowerService
- [x] Add Charge-Voltage, Re-Charge-Voltage, Pre-Charge-Current and Termination-Current handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone BMS service for battery telemetry, periodic driver updates, and extra JSON telemetry
  * Added charger controls: adjustable charging voltage and selectable recharge-voltage settings

* **Refactor**
  * Split power service into separate service and driver tick paths; charger config now uses robot defaults when unspecified
  * Charger telemetry surfaced in the UI and robot displays; BMS is now optional/conditional on hardware presence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xtech/fw-openmower-v2/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->