### PR TITLE
Add parameter Dangerously Override Hardware Current Limit

### DIFF
--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -112,7 +112,9 @@ void PowerService::charger_tick() {
       success &= charger_->setPreChargeCurrent(0.250f);
       success &= charger_->setTerminationCurrent(0.250f);
       if (ChargeCurrent.valid && ChargeCurrent.value > 0) {
-        success &= charger_->setChargingCurrent(ChargeCurrent.value, false);
+        bool override_limit =
+            DangerouslyOverrideHardwareCurrentLimit.valid && DangerouslyOverrideHardwareCurrentLimit.value;
+        success &= charger_->setChargingCurrent(ChargeCurrent.value, override_limit);
       } else {
         success &= charger_->setChargingCurrent(robot->Power_GetDefaultChargeCurrent(), false);
       }

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -25,6 +25,10 @@ void PowerService::SetDriver(BmsDriver* bms_driver) {
 
 bool PowerService::OnStart() {
   charger_configured_ = false;
+  if (DangerouslyOverrideHardwareCurrentLimit.valid && DangerouslyOverrideHardwareCurrentLimit.value) {
+    ULOG_ARG_WARNING(&service_id_,
+                     "DangerouslyOverrideHardwareCurrentLimit is set - hardware current limits will be bypassed!");
+  }
   return true;
 }
 

--- a/src/services/power_service/power_service.cpp
+++ b/src/services/power_service/power_service.cpp
@@ -25,9 +25,10 @@ void PowerService::SetDriver(BmsDriver* bms_driver) {
 
 bool PowerService::OnStart() {
   charger_configured_ = false;
-  if (DangerouslyOverrideHardwareCurrentLimit.valid && DangerouslyOverrideHardwareCurrentLimit.value) {
-    ULOG_ARG_WARNING(&service_id_,
-                     "DangerouslyOverrideHardwareCurrentLimit is set - hardware current limits will be bypassed!");
+  if (DangerouslyOverrideHardwareChargeCurrentLimit.valid && DangerouslyOverrideHardwareChargeCurrentLimit.value) {
+    ULOG_ARG_WARNING(
+        &service_id_,
+        "DangerouslyOverrideHardwareChargeCurrentLimit is set - hardware current limits will be bypassed!");
   }
   return true;
 }
@@ -117,7 +118,7 @@ void PowerService::charger_tick() {
       success &= charger_->setTerminationCurrent(0.250f);
       if (ChargeCurrent.valid && ChargeCurrent.value > 0) {
         bool override_limit =
-            DangerouslyOverrideHardwareCurrentLimit.valid && DangerouslyOverrideHardwareCurrentLimit.value;
+            DangerouslyOverrideHardwareChargeCurrentLimit.valid && DangerouslyOverrideHardwareChargeCurrentLimit.value;
         success &= charger_->setChargingCurrent(ChargeCurrent.value, override_limit);
       } else {
         success &= charger_->setChargingCurrent(robot->Power_GetDefaultChargeCurrent(), false);


### PR DESCRIPTION
This parameter should make it possible voor V2 hardware users to set the Charge Current to a value that might endanger hardware. By default, the Charge Current is max 1A.

Adding
` /ll/services/power/dangerously_override_hardware_current_limit: true
`in mower_params.yaml overrides this maximum.

This parameter requires changes in 3 repositories. The pull requests all have the same name.

### https://github.com/xtech/definitions-open-mower

Definitions-open-mower is used by fw-openmower-v2 and by
open_mower_ros. At testing time, they used an older version, commit
services @ dad32a9

This pull request adds the definition of
  "Dangerously Override Hardware Current Limit"

### https://github.com/xtech/fw-openmower-v2

This pull request adds reading the optional value of
 "Dangerously Override Hardware Current Limit" from ROS.
If set, it will allow higher Charge Currents then 1A

### https://github.com/ClemensElflein/open_mower_ros

This pull request adds reading dangerously_override_hardware_current_limit
from open_mower.yaml and making it available to ROS.

### These pull requests have been tested against:

- definitions-open-mower @ dad32a9
- fw-openmower-v2 @ 3b39af2
- open_mower_ros @ da7a52a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logs a warning at startup when a hardware charge-current override is configured.
  * Motor drivers expose an explicit disable action for safer shutdown.

* **Bug Fixes**
  * Charger configuration now respects the hardware charge-current override when applied.
  * Emergency handling reliably disables motors instead of only commanding zero duty.

* **Chores**
  * Updated services subproject reference and CI release job configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xtech/fw-openmower-v2/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->