### PR TITLE
Add YF Cover UI driver for YardForce 500 platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,8 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         src/drivers/input/sabo_input_driver.cpp
         src/drivers/input/worx_input_driver.cpp
         $<$<BOOL:${DEBUG_BUILD}>:src/drivers/input/simulated_input_driver.cpp>
+        # YardForce Cover UI driver (yf_cover_ui — YardForce 500 panel via UART7)
+        src/drivers/ui/yf_cover_ui/yf_cover_ui.cpp
         # Sabo driver
         src/drivers/ui/SaboCoverUI/sabo_cover_ui_cabo_driver_base.cpp
         src/drivers/ui/SaboCoverUI/sabo_cover_ui_controller.cpp

--- a/boards/XCORE/mcuconf.h
+++ b/boards/XCORE/mcuconf.h
@@ -365,7 +365,7 @@
 #define STM32_SERIAL_USE_UART4              FALSE
 #define STM32_SERIAL_USE_UART5              FALSE
 #define STM32_SERIAL_USE_USART6             FALSE
-#define STM32_SERIAL_USE_UART7              FALSE
+#define STM32_SERIAL_USE_UART7              TRUE   /* CoverUI on YardForce (UART7, LED_TX/LED_RX) */
 #define STM32_SERIAL_USE_UART8              FALSE
 #define STM32_SERIAL_USE_UART9              FALSE
 #define STM32_SERIAL_USE_USART10            FALSE
@@ -441,7 +441,7 @@
 #define STM32_UART_USE_UART4                TRUE
 #define STM32_UART_USE_UART5                FALSE
 #define STM32_UART_USE_USART6               TRUE
-#define STM32_UART_USE_UART7                TRUE
+#define STM32_UART_USE_UART7                FALSE  /* UART7 used as SerialDriver for CoverUI */
 #define STM32_UART_USE_UART8                TRUE
 #define STM32_UART_USE_UART9                FALSE
 #define STM32_UART_USE_USART10              TRUE

--- a/cfg/halconf.h
+++ b/cfg/halconf.h
@@ -142,7 +142,7 @@
  * @brief   Enables the SERIAL subsystem.
  */
 #if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
-#define HAL_USE_SERIAL                      FALSE
+#define HAL_USE_SERIAL                      TRUE
 #endif
 
 /**

--- a/robots/include/yardforce_robot.hpp
+++ b/robots/include/yardforce_robot.hpp
@@ -2,6 +2,7 @@
 #define YARDFORCE_ROBOT_HPP
 
 #include <drivers/charger/bq_2576/bq_2576.hpp>
+#include <drivers/ui/yf_cover_ui/yf_cover_ui.hpp>
 
 #include "robot.hpp"
 
@@ -36,6 +37,7 @@ class YardForceRobot : public MowerRobot {
 
  private:
   BQ2576 charger_{249000, 14040};
+  xbot::driver::ui::YFCoverUI yf_cover_ui_{};
 };
 
 #endif  // YARDFORCE_ROBOT_HPP

--- a/robots/src/yardforce_robot.cpp
+++ b/robots/src/yardforce_robot.cpp
@@ -6,6 +6,12 @@ void YardForceRobot::InitPlatform() {
   InitMotors();
   charger_.setI2C(&I2CD1);
   power_service.SetDriver(&charger_);
+
+#ifndef STM32_SERIAL_USE_UART7
+#error STM32_SERIAL_USE_UART7 must be enabled for the YF Cover UI to work
+#endif
+  input_service.RegisterInputDriver("yf_cover_ui", &yf_cover_ui_);
+  yf_cover_ui_.Start(&SERIALD7);
 }
 
 bool YardForceRobot::IsHardwareSupported() {

--- a/src/drivers/input/input_driver.hpp
+++ b/src/drivers/input/input_driver.hpp
@@ -37,6 +37,10 @@ struct Input {
         xbot::driver::sabo::types::ButtonId button_id;
       } id;
     } sabo;
+
+    struct {
+      uint8_t channel;  ///< YFCoverUIChannel value: bit 7=button flag, bits[6:0]=button_id or emergency bit
+    } yf_cover_ui;
   };
 
   // State

--- a/src/drivers/ui/yf_cover_ui/yf_cover_ui.cpp
+++ b/src/drivers/ui/yf_cover_ui/yf_cover_ui.cpp
@@ -1,0 +1,465 @@
+/*
+ * OpenMower V2 Firmware
+ * Part of the OpenMower V2 Firmware (https://github.com/xtech/fw-openmower-v2)
+ *
+ * Copyright (C) 2026 The OpenMower Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "yf_cover_ui.hpp"
+
+#include <EmergencyServiceBase.hpp>
+#include <HighLevelServiceBase.hpp>
+#include <etl/crc16_ccitt.h>
+#include <etl/string_view.h>
+#include <json_stream.hpp>
+#include <ulog.h>
+
+#include <services.hpp>
+
+namespace xbot::driver::ui {
+
+using namespace xbot::driver::input;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+static constexpr uint32_t VERSION_POLL_MS  = 5000;  ///< How often to poll UI version
+static constexpr uint32_t VERSION_TIMEOUT_MS = 100; ///< How long to wait for version reply
+static constexpr uint32_t LED_UPDATE_INTERVAL_DEFAULT_MS = 1000;
+
+// ============================================================================
+// Public
+// ============================================================================
+
+void YFCoverUI::Start(SerialDriver* sd) {
+  if (thread_ != nullptr) {
+    ULOG_ERROR("YFCoverUI: Start() called twice!");
+    return;
+  }
+  if (sd == nullptr) {
+    ULOG_ERROR("YFCoverUI: null SerialDriver!");
+    return;
+  }
+
+  sd_ = sd;
+
+  static const SerialConfig serial_cfg = {
+      .speed = 115200,
+      .cr1   = 0,
+      .cr2   = USART_CR2_STOP1_BITS,
+      .cr3   = 0,
+  };
+  sdStart(sd_, &serial_cfg);
+
+  thread_ = chThdCreateStatic(&wa_, sizeof(wa_), NORMALPRIO - 1, ThreadHelper, this);
+#ifdef USE_SEGGER_SYSTEMVIEW
+  thread_->name = "YFCoverUI";
+#endif
+}
+
+bool YFCoverUI::OnInputConfigValue(lwjson_stream_parser_t* jsp, const char* key,
+                                      lwjson_stream_type_t type, Input& input) {
+  if (strcmp(key, "channel") == 0) {
+    JsonExpectType(STRING);
+    etl::string_view ch{jsp->data.str.buff};
+    if (ch == "latch")  { input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::LATCH);  return true; }
+    if (ch == "stop1")  { input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::STOP1);  return true; }
+    if (ch == "stop2")  { input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::STOP2);  return true; }
+    if (ch == "lift")   { input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::LIFT);   return true; }
+    if (ch == "liftx")  { input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::LIFTX);  return true; }
+    if (ch == "button") {
+      // Set the button flag bit; the button_id bits [6:0] will be filled by the "button_id" key.
+      input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::BUTTON_FLAG);
+      return true;
+    }
+    ULOG_ERROR("YFCoverUI: unknown channel \"%s\"", jsp->data.str.buff);
+    return false;
+  }
+  if (strcmp(key, "button_id") == 0) {
+    uint8_t button_id = 0;
+    if (!JsonGetNumber(jsp, type, button_id)) return false;
+    // Store the button_id in bits [6:0]; preserve bit 7 (BUTTON_FLAG) set by "channel":"button".
+    input.yf_cover_ui.channel = static_cast<uint8_t>(YFCoverUIChannel::BUTTON_FLAG) | (button_id & 0x7F);
+    return true;
+  }
+  ULOG_ERROR("YFCoverUI: unknown attribute \"%s\"", key);
+  return false;
+}
+
+// ============================================================================
+// Thread
+// ============================================================================
+
+void YFCoverUI::ThreadHelper(void* instance) {
+  static_cast<YFCoverUI*>(instance)->ThreadFunc();
+}
+
+void YFCoverUI::ThreadFunc() {
+  systime_t next_version_poll = chVTGetSystemTimeX();
+  systime_t version_timeout   = 0;  // 0 = no pending timeout
+  systime_t next_led_update   = chVTGetSystemTimeX() + TIME_MS2I(500);
+
+  while (true) {
+    // --- Read incoming bytes (10 ms timeout keeps the loop responsive) ---
+    ReadByte(TIME_MS2I(10));
+
+    const systime_t now = chVTGetSystemTimeX();
+
+    // --- Version timeout: mark UI unavailable if no response within 100 ms ---
+    if (version_timeout != 0 && chTimeDiffX(version_timeout, now) >= 0) {
+      if (ui_available_.load()) {
+        ULOG_INFO("YFCoverUI: UI timeout, marking unavailable");
+        ui_available_.store(false);
+        emergency_state_.store(0);
+        UpdateEmergencyInputs();
+      }
+      version_timeout = 0;
+    }
+
+    // --- Periodic version poll (every 5 s) ---
+    if (chTimeDiffX(next_version_poll, now) >= 0) {
+      SendVersionRequest();
+      next_version_poll = now + TIME_MS2I(VERSION_POLL_MS);
+      version_timeout   = now + TIME_MS2I(VERSION_TIMEOUT_MS);
+    }
+
+    // --- Periodic LED update ---
+    if (chTimeDiffX(next_led_update, now) >= 0) {
+      SendLeds();
+      next_led_update = now + TIME_MS2I(ui_interval_);
+    }
+  }
+}
+
+// ============================================================================
+// Protocol TX
+// ============================================================================
+
+void YFCoverUI::SendMessage(const void* msg, size_t size) {
+  if (sd_ == nullptr) return;
+
+  // Encode with COBS into a local buffer (max encoded size = size + 2 overhead + 1 delimiter)
+  static constexpr size_t ENC_BUF_SIZE = 32;
+  uint8_t enc[ENC_BUF_SIZE];
+
+  size_t enc_len = CobsEncode(static_cast<const uint8_t*>(msg), size, enc);
+  enc[enc_len++] = 0x00;  // COBS packet delimiter
+
+  sdWrite(sd_, enc, enc_len);
+}
+
+void YFCoverUI::SendVersionRequest() {
+  msg_get_version msg{};
+  msg.type    = Get_Version;
+  msg.version = 0;
+  msg.crc     = CalcCRC(reinterpret_cast<const uint8_t*>(&msg), sizeof(msg) - sizeof(msg.crc));
+  SendMessage(&msg, sizeof(msg));
+}
+
+void YFCoverUI::SendLeds() {
+  msg_set_leds leds_msg{};
+  leds_msg.type = Set_LEDs;
+  BuildLedMessage(leds_msg);
+  leds_msg.crc = CalcCRC(reinterpret_cast<const uint8_t*>(&leds_msg),
+                         sizeof(leds_msg) - sizeof(leds_msg.crc));
+  SendMessage(&leds_msg, sizeof(leds_msg));
+}
+
+void YFCoverUI::BuildLedMessage(msg_set_leds& msg) {
+  // ---- Battery / charging ----
+  const float battery_volts  = power_service.GetBatteryVolts();
+  const float adapter_volts  = power_service.GetAdapterVolts();
+  const float charge_current = power_service.GetChargeCurrent();
+  const float battery_pct    = power_service.GetBatteryPercent();  // 0.0–1.0
+
+  // Charging LED: fast-blink=high current, slow-blink=trickle, on=charged/docked
+  if (adapter_volts > 20.0f) {  // Docked (adapter present)
+    if (charge_current > 0.5f) {
+      setLed(msg, LED_CHARGING, LED_blink_fast);
+    } else if (charge_current > 0.05f) {
+      setLed(msg, LED_CHARGING, LED_blink_slow);
+    } else {
+      setLed(msg, LED_CHARGING, LED_on);  // Charged
+    }
+  } else {
+    setLed(msg, LED_CHARGING, LED_off);
+  }
+
+  // Battery low LED
+  const bool battery_low = !std::isnan(battery_pct) && battery_pct < 0.20f;
+  setLed(msg, LED_BATTERY_LOW, battery_low ? LED_on : LED_off);
+
+  // Battery bar (LED5–LED11, 7 segments)
+  if (!std::isnan(battery_pct)) {
+    setBars7(msg, static_cast<double>(battery_pct));
+  }
+
+  // ---- GPS quality ----
+  const float gps_quality = high_level_service.GetGpsQuality();  // 0–100, or negative
+
+  // GPS bar (LED15–LED18, 4 segments)
+  if (std::isnan(gps_quality) || gps_quality < 0.0f) {
+    setBars4(msg, -1.0);  // Fast-blink all = needs calibration / no fix
+    setLed(msg, LED_POOR_GPS, LED_blink_fast);
+  } else {
+    setBars4(msg, static_cast<double>(gps_quality) / 100.0);
+    setLed(msg, LED_POOR_GPS, gps_quality < 25.0f ? LED_on : LED_off);
+  }
+
+  // ---- High-level state (S1, S2 mode LEDs) ----
+  const HighLevelStatus hl_status = high_level_service.GetStateId();
+  const uint8_t SUBSTATE_SHIFT    = static_cast<uint8_t>(HighLevelStatus::SUBSTATE_SHIFT);
+  const uint8_t STATE_MASK        = static_cast<uint8_t>((1 << SUBSTATE_SHIFT) - 1);
+  const uint8_t SUBSTATE_MASK     = static_cast<uint8_t>(HighLevelStatus::SUBSTATE_MASK);
+
+  const uint8_t hl_raw       = static_cast<uint8_t>(hl_status);
+  const HighLevelStatus main_state = static_cast<HighLevelStatus>(hl_raw & STATE_MASK);
+  const HighLevelStatus sub_state  = static_cast<HighLevelStatus>((hl_raw >> SUBSTATE_SHIFT) & SUBSTATE_MASK);
+
+  // S1 = autonomous mowing
+  if (main_state == HighLevelStatus::AUTONOMOUS && sub_state == HighLevelStatus::SUBSTATE_1) {
+    setLed(msg, LED_S1, LED_on);
+  } else if (main_state == HighLevelStatus::AUTONOMOUS) {
+    setLed(msg, LED_S1, LED_blink_slow);  // Autonomous but not mowing (e.g. navigating)
+  } else {
+    setLed(msg, LED_S1, LED_off);
+  }
+
+  // S2 = docking / undocking
+  if (main_state == HighLevelStatus::AUTONOMOUS &&
+      (sub_state == HighLevelStatus::SUBSTATE_2 || sub_state == HighLevelStatus::SUBSTATE_3)) {
+    setLed(msg, LED_S2, LED_on);
+  } else if (main_state == HighLevelStatus::RECORDING) {
+    setLed(msg, LED_S2, LED_blink_slow);  // Recording mode
+  } else {
+    setLed(msg, LED_S2, LED_off);
+  }
+
+  // ---- Emergency / mower-lifted LED ----
+  const uint16_t emergency_reasons = emergency_service.GetEmergencyReasons();
+  const bool stop_active   = (emergency_reasons & EmergencyReason::STOP) != 0;
+  const bool lift_active   = (emergency_reasons & (EmergencyReason::LIFT | EmergencyReason::LIFT_MULTIPLE)) != 0;
+  const bool latch_active  = (emergency_state_.load() & Emergency_latch) != 0;
+
+  if (stop_active) {
+    setLed(msg, LED_MOWER_LIFTED, LED_blink_fast);  // Stop button pressed
+  } else if (lift_active) {
+    setLed(msg, LED_MOWER_LIFTED, LED_blink_slow);  // Lifted
+  } else if (latch_active) {
+    setLed(msg, LED_MOWER_LIFTED, LED_on);           // Latched emergency
+  } else {
+    setLed(msg, LED_MOWER_LIFTED, LED_off);
+  }
+
+  (void)battery_volts;  // Available for future use (e.g. LOCK LED logic)
+}
+
+// ============================================================================
+// Protocol RX
+// ============================================================================
+
+void YFCoverUI::ReadByte(sysinterval_t timeout) {
+  msg_t byte = sdGetTimeout(sd_, timeout);
+  if (byte == MSG_TIMEOUT || byte == MSG_RESET) {
+    return;
+  }
+
+  const uint8_t b = static_cast<uint8_t>(byte);
+
+  if (b == 0x00) {
+    // End of COBS packet — decode and dispatch if we have data
+    if (rx_len_ > 0) {
+      size_t decoded_len = 0;
+      if (CobsDecode(rx_buf_, rx_len_, decode_buf_, decoded_len)) {
+        HandleMessage(decode_buf_, decoded_len);
+      } else {
+        ULOG_WARNING("YFCoverUI: COBS decode error (len=%u)", (unsigned)rx_len_);
+      }
+      rx_len_ = 0;
+    }
+  } else {
+    if (rx_len_ < RX_BUF_SIZE) {
+      rx_buf_[rx_len_++] = b;
+    } else {
+      // Buffer overflow — discard accumulated data and start over
+      ULOG_WARNING("YFCoverUI: RX buffer overflow, discarding");
+      rx_len_ = 0;
+    }
+  }
+}
+
+void YFCoverUI::HandleMessage(const uint8_t* buf, size_t len) {
+  if (len < 1) return;
+
+  // Validate CRC (last 2 bytes are the CRC, over all preceding bytes)
+  if (len < 3) {
+    ULOG_WARNING("YFCoverUI: message too short (%u bytes)", (unsigned)len);
+    return;
+  }
+  const uint16_t received_crc = static_cast<uint16_t>(buf[len - 2]) |
+                                 (static_cast<uint16_t>(buf[len - 1]) << 8);
+  const uint16_t computed_crc = CalcCRC(buf, len - 2);
+  if (received_crc != computed_crc) {
+    ULOG_WARNING("YFCoverUI: CRC mismatch (got 0x%04X, expected 0x%04X)",
+                 received_crc, computed_crc);
+    return;
+  }
+
+  switch (buf[0]) {
+    case Get_Version:
+      if (len == sizeof(msg_get_version)) {
+        HandleVersion(reinterpret_cast<const msg_get_version*>(buf));
+      }
+      break;
+    case Get_Button:
+      if (len == sizeof(msg_event_button)) {
+        HandleButton(reinterpret_cast<const msg_event_button*>(buf));
+      }
+      break;
+    case Get_Emergency:
+      if (len == sizeof(msg_event_emergency)) {
+        HandleEmergency(reinterpret_cast<const msg_event_emergency*>(buf));
+      }
+      break;
+    case Get_Rain:
+      if (len == sizeof(msg_event_rain)) {
+        HandleRain(reinterpret_cast<const msg_event_rain*>(buf));
+      }
+      break;
+    case Get_Subscribe:
+      if (len == sizeof(msg_event_subscribe)) {
+        HandleSubscribe(reinterpret_cast<const msg_event_subscribe*>(buf));
+      }
+      break;
+    default:
+      ULOG_WARNING("YFCoverUI: unknown message type 0x%02X", buf[0]);
+      break;
+  }
+}
+
+void YFCoverUI::HandleVersion(const msg_get_version* msg) {
+  ULOG_DEBUG("YFCoverUI: version response, UI firmware v%u", msg->version);
+  ui_available_.store(true);
+}
+
+void YFCoverUI::HandleButton(const msg_event_button* msg) {
+  ULOG_DEBUG("YFCoverUI: button %u pressed (duration %u)", msg->button_id, msg->press_duration);
+
+  const uint8_t btn_id = static_cast<uint8_t>(msg->button_id & 0x7F);
+  const bool long_press = (msg->press_duration >= 1);
+
+  // Inject press into any registered Input configured as a button with matching button_id.
+  // Button inputs are identified by bit 7 of channel being set (BUTTON_FLAG).
+  // Bits [6:0] of channel carry the configured button_id.
+  for (auto& input : Inputs()) {
+    if (YFCoverUIChannelIsButton(input.yf_cover_ui.channel) &&
+        YFCoverUIChannelButtonId(input.yf_cover_ui.channel) == btn_id) {
+      input.InjectPress(long_press);
+    }
+  }
+}
+
+void YFCoverUI::HandleEmergency(const msg_event_emergency* msg) {
+  ULOG_DEBUG("YFCoverUI: emergency state 0x%02X", msg->state);
+  emergency_state_.store(msg->state);
+  UpdateEmergencyInputs();
+}
+
+void YFCoverUI::HandleRain(const msg_event_rain* msg) {
+  const bool raining = (msg->value < msg->threshold);
+  ULOG_DEBUG("YFCoverUI: rain sensor value=%lu threshold=%lu raining=%d",
+             (unsigned long)msg->value, (unsigned long)msg->threshold, (int)raining);
+  rain_detected_.store(raining);
+}
+
+void YFCoverUI::HandleSubscribe(const msg_event_subscribe* msg) {
+  ULOG_DEBUG("YFCoverUI: subscribe topics=0x%02X interval=%u ms",
+             msg->topic_bitmask, msg->interval);
+  if (msg->interval > 0) {
+    ui_interval_ = msg->interval;
+  }
+}
+
+void YFCoverUI::UpdateEmergencyInputs() {
+  const uint8_t state = emergency_state_.load();
+  for (auto& input : Inputs()) {
+    const uint8_t ch = input.yf_cover_ui.channel;
+    if (!YFCoverUIChannelIsButton(ch)) {
+      // Emergency channel (bit 7 = 0) — update based on corresponding bit in state
+      const bool active = (state & (1u << ch)) != 0;
+      input.Update(active);
+    }
+  }
+}
+
+// ============================================================================
+// CRC-16/CCITT
+// ============================================================================
+
+uint16_t YFCoverUI::CalcCRC(const uint8_t* buf, size_t len) {
+  etl::crc16_ccitt crc;
+  crc.add(buf, buf + len);
+  return crc.value();
+}
+
+// ============================================================================
+// COBS encode / decode
+// ============================================================================
+
+size_t YFCoverUI::CobsEncode(const uint8_t* src, size_t src_len, uint8_t* dst) {
+  size_t  dst_idx   = 0;
+  size_t  code_idx  = 0;     // index of the "overhead" / code byte for the current block
+  uint8_t code      = 0x01;  // distance to next 0x00 (or end of data + 1)
+
+  dst[dst_idx++] = 0x00;  // placeholder for first overhead byte
+  code_idx = dst_idx - 1;
+
+  for (size_t i = 0; i < src_len; i++) {
+    if (src[i] == 0x00) {
+      // Write current code byte and start a new block
+      dst[code_idx] = code;
+      code_idx = dst_idx;
+      dst[dst_idx++] = 0x01;
+      code = 0x01;
+    } else {
+      dst[dst_idx++] = src[i];
+      code++;
+      if (code == 0xFF) {
+        // Block of 254 non-zero bytes — start a new block
+        dst[code_idx] = code;
+        code_idx = dst_idx;
+        dst[dst_idx++] = 0x01;
+        code = 0x01;
+      }
+    }
+  }
+  dst[code_idx] = code;
+  return dst_idx;
+}
+
+bool YFCoverUI::CobsDecode(const uint8_t* src, size_t src_len, uint8_t* dst, size_t& out_len) {
+  out_len = 0;
+  size_t i = 0;
+
+  while (i < src_len) {
+    const uint8_t code = src[i++];
+    if (code == 0x00) {
+      return false;  // Unexpected 0x00 inside a COBS packet
+    }
+    const uint8_t block = code - 1u;
+    for (uint8_t j = 0; j < block; j++) {
+      if (i >= src_len) return false;  // Truncated packet
+      dst[out_len++] = src[i++];
+    }
+    // Append a 0x00 unless this was an "all-non-zero" block (code==0xFF) or end of input
+    if (code != 0xFF && i < src_len) {
+      dst[out_len++] = 0x00;
+    }
+  }
+  return true;
+}
+
+}  // namespace xbot::driver::ui

--- a/src/drivers/ui/yf_cover_ui/yf_cover_ui.cpp
+++ b/src/drivers/ui/yf_cover_ui/yf_cover_ui.cpp
@@ -98,38 +98,39 @@ void YFCoverUI::ThreadHelper(void* instance) {
 }
 
 void YFCoverUI::ThreadFunc() {
-  systime_t next_version_poll = chVTGetSystemTimeX();
-  systime_t version_timeout   = 0;  // 0 = no pending timeout
-  systime_t next_led_update   = chVTGetSystemTimeX() + TIME_MS2I(500);
+  // Schedule the first version poll immediately and the first LED update after 500 ms.
+  systime_t last_version_poll = chVTGetSystemTimeX() - TIME_MS2I(VERSION_POLL_MS);
+  systime_t version_request   = 0;     // systime of the pending version request
+  bool      version_pending   = false;  // true while awaiting a version response
+  systime_t last_led_update   = chVTGetSystemTimeX() - TIME_MS2I(500);
 
   while (true) {
     // --- Read incoming bytes (10 ms timeout keeps the loop responsive) ---
     ReadByte(TIME_MS2I(10));
 
-    const systime_t now = chVTGetSystemTimeX();
-
-    // --- Version timeout: mark UI unavailable if no response within 100 ms ---
-    if (version_timeout != 0 && chTimeDiffX(version_timeout, now) >= 0) {
+    // --- Version timeout: mark UI unavailable if no response within VERSION_TIMEOUT_MS ---
+    if (version_pending && chVTTimeElapsedSinceX(version_request) >= TIME_MS2I(VERSION_TIMEOUT_MS)) {
       if (ui_available_.load()) {
         ULOG_INFO("YFCoverUI: UI timeout, marking unavailable");
         ui_available_.store(false);
         emergency_state_.store(0);
         UpdateEmergencyInputs();
       }
-      version_timeout = 0;
+      version_pending = false;
     }
 
     // --- Periodic version poll (every 5 s) ---
-    if (chTimeDiffX(next_version_poll, now) >= 0) {
+    if (chVTTimeElapsedSinceX(last_version_poll) >= TIME_MS2I(VERSION_POLL_MS)) {
       SendVersionRequest();
-      next_version_poll = now + TIME_MS2I(VERSION_POLL_MS);
-      version_timeout   = now + TIME_MS2I(VERSION_TIMEOUT_MS);
+      last_version_poll = chVTGetSystemTimeX();
+      version_request   = last_version_poll;
+      version_pending   = true;
     }
 
     // --- Periodic LED update ---
-    if (chTimeDiffX(next_led_update, now) >= 0) {
+    if (chVTTimeElapsedSinceX(last_led_update) >= TIME_MS2I(ui_interval_)) {
       SendLeds();
-      next_led_update = now + TIME_MS2I(ui_interval_);
+      last_led_update = chVTGetSystemTimeX();
     }
   }
 }

--- a/src/drivers/ui/yf_cover_ui/yf_cover_ui.hpp
+++ b/src/drivers/ui/yf_cover_ui/yf_cover_ui.hpp
@@ -1,0 +1,167 @@
+/*
+ * OpenMower V2 Firmware
+ * Part of the OpenMower V2 Firmware (https://github.com/xtech/fw-openmower-v2)
+ *
+ * Copyright (C) 2026 The OpenMower Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * @file yf_cover_ui.hpp
+ * @brief Driver for the YardForce Cover UI (yf_cover_ui) panel on the YardForce 500 mower.
+ *
+ * The YF Cover UI board communicates via UART7 at 115200 baud using COBS packet framing
+ * and CRC-16/CCITT error detection. This driver:
+ *  - Polls the YF Cover UI for presence every 5 s
+ *  - Sends LED state updates at a configurable interval (default 1 s)
+ *  - Forwards button events and emergency signals to the InputService
+ *  - Reads rain sensor data from the YF Cover UI board
+ *
+ * The driver extends InputDriver so that emergency and button inputs are routed
+ * through the standard InputService / EmergencyService pipeline.
+ */
+
+#ifndef YF_COVER_UI_HPP
+#define YF_COVER_UI_HPP
+
+#include <etl/atomic.h>
+#include <hal.h>
+#include <lwjson/lwjson.h>
+
+#include <drivers/input/input_driver.hpp>
+
+#include "yf_cover_ui_protocol.hpp"
+
+namespace xbot::driver::ui {
+
+using namespace xbot::driver::input;
+
+/**
+ * @brief Channel encoding for YF Cover UI inputs, stored in Input::yf_cover_ui.channel.
+ *
+ * Bit layout:
+ *   bit 7 = 0 → emergency channel; bits [4:0] = Emergency_state bit position (0–4)
+ *   bit 7 = 1 → button channel;    bits [6:0] = button_id from msg_event_button
+ *
+ * Emergency channels are updated by HandleEmergency() from the Emergency_state bitmask.
+ * Button channels are triggered by HandleButton() when button_id matches bits [6:0].
+ *
+ * Use BUTTON_FLAG (0x80) OR'd with the button_id to form a button channel value.
+ * Use YFCoverUIChannelIsButton() and YFCoverUIChannelButtonId() helpers to test and extract.
+ */
+enum class YFCoverUIChannel : uint8_t {
+  // Emergency channels — map to Emergency_state bits (bit 7 = 0)
+  LATCH = 0,   ///< Emergency latch (bit 0 of Emergency_state)
+  STOP1 = 1,   ///< Stop button 1  (bit 1 of Emergency_state)
+  STOP2 = 2,   ///< Stop button 2  (bit 2 of Emergency_state)
+  LIFT  = 3,   ///< Lift sensor 1  (bit 3 of Emergency_state)
+  LIFTX = 4,   ///< Lift sensor 2  (bit 4 of Emergency_state)
+  // Button channels — bit 7 set, lower 7 bits carry the button_id
+  BUTTON_FLAG = 0x80,  ///< OR with button_id to encode a button channel
+};
+
+/** @return true if the encoded channel byte represents a button (not an emergency). */
+constexpr bool YFCoverUIChannelIsButton(uint8_t ch) { return (ch & 0x80) != 0; }
+/** @return the button_id stored in an encoded button channel byte. */
+constexpr uint8_t YFCoverUIChannelButtonId(uint8_t ch) { return ch & 0x7F; }
+
+class YFCoverUI : public InputDriver {
+ public:
+  /**
+   * @brief Start the YF Cover UI driver on the given serial port.
+   *
+   * Configures SERIALD7 at 115200 baud and spawns the communication thread.
+   * Must be called from InitPlatform() before the scheduler starts.
+   *
+   * @param sd  Pointer to the ChibiOS SerialDriver (use &SERIALD7).
+   */
+  void Start(SerialDriver* sd);
+
+  /** @return true if the YF Cover UI panel is connected and responding. */
+  bool IsAvailable() const {
+    return ui_available_.load();
+  }
+
+  /** @return true if rain is currently detected by the YF Cover UI rain sensor. */
+  bool IsRainDetected() const {
+    return rain_detected_.load();
+  }
+
+  // ---- InputDriver interface ----
+
+  /**
+   * @brief Parse input configuration from the JSON sent by open_mower_ros.
+   *
+   * Recognised keys:
+   *  - "channel": "latch"|"stop1"|"stop2"|"lift"|"liftx"
+   *               → emergency channel; stores bit position (0–4) in channel byte.
+   *  - "channel": "button"
+   *               → button channel; sets bit 7 in channel byte.
+   *               Requires a subsequent "button_id" key.
+   *  - "button_id": <uint> (0–127)
+   *               → button_id sent by the YF Cover UI in msg_event_button.
+   *               Must be combined with "channel":"button".
+   *               Stored in bits [6:0] of the channel byte (bit 7 remains set).
+   */
+  bool OnInputConfigValue(lwjson_stream_parser_t* jsp, const char* key, lwjson_stream_type_t type,
+                          Input& input) override;
+
+ private:
+  SerialDriver* sd_ = nullptr;
+
+  etl::atomic<bool>     ui_available_{false};
+  etl::atomic<uint8_t>  emergency_state_{0};   ///< Last received emergency bitmask
+  etl::atomic<bool>     rain_detected_{false};
+  uint16_t              ui_interval_ = 1000;   ///< LED update interval in ms (from Subscribe msg)
+
+  // COBS receive buffer. Maximum unencoded message is sizeof(msg_event_rain)=12, so 20 bytes
+  // of encoded data is plenty with the COBS overhead byte and delimiter.
+  static constexpr size_t RX_BUF_SIZE = 32;
+  uint8_t rx_buf_[RX_BUF_SIZE]{};
+  size_t  rx_len_ = 0;
+
+  // Decoded payload buffer
+  static constexpr size_t DECODE_BUF_SIZE = 24;
+  uint8_t decode_buf_[DECODE_BUF_SIZE]{};
+
+  // Thread
+  THD_WORKING_AREA(wa_, 2048);
+  thread_t* thread_ = nullptr;
+
+  static void ThreadHelper(void* instance);
+  void ThreadFunc();
+
+  // ---- Protocol TX ----
+  void SendMessage(const void* msg, size_t size);
+  void SendVersionRequest();
+  void SendLeds();
+  void BuildLedMessage(msg_set_leds& leds_msg);
+
+  // ---- Protocol RX ----
+  /**
+   * @brief Read one byte from the serial port (with timeout) and feed COBS decoder.
+   *
+   * When a complete packet (terminated by 0x00) is received, calls HandleMessage().
+   * @param timeout_ms  sdGetTimeout() timeout in milliseconds.
+   */
+  void ReadByte(sysinterval_t timeout_ms);
+  void HandleMessage(const uint8_t* buf, size_t len);
+  void HandleVersion(const msg_get_version* msg);
+  void HandleButton(const msg_event_button* msg);
+  void HandleEmergency(const msg_event_emergency* msg);
+  void HandleRain(const msg_event_rain* msg);
+  void HandleSubscribe(const msg_event_subscribe* msg);
+
+  /** @brief Update all emergency Input objects from the current emergency_state_. */
+  void UpdateEmergencyInputs();
+
+  // ---- CRC & COBS ----
+  static uint16_t CalcCRC(const uint8_t* buf, size_t len);
+  static size_t   CobsEncode(const uint8_t* src, size_t src_len, uint8_t* dst);
+  static bool     CobsDecode(const uint8_t* src, size_t src_len, uint8_t* dst, size_t& out_len);
+};
+
+}  // namespace xbot::driver::ui
+
+#endif  // YF_COVER_UI_HPP

--- a/src/drivers/ui/yf_cover_ui/yf_cover_ui_protocol.hpp
+++ b/src/drivers/ui/yf_cover_ui/yf_cover_ui_protocol.hpp
@@ -1,0 +1,200 @@
+/*
+ * OpenMower V2 Firmware
+ * Part of the OpenMower V2 Firmware (https://github.com/xtech/fw-openmower-v2)
+ *
+ * Copyright (C) 2026 The OpenMower Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/**
+ * @file yf_cover_ui_protocol.hpp
+ * @brief Protocol definitions for the YardForce Cover UI (yf_cover_ui) (Yardforce 500 type).
+ *
+ * This protocol is used by the Yardforce 500 mower's front panel (YF Cover UI board).
+ * Communication is UART at 115200 baud with COBS packet framing and CRC-16/CCITT.
+ *
+ * Ported from OpenMower/Firmware/LowLevel/src/ui_board.h (original by Elmar Elflein).
+ */
+
+#ifndef YF_COVER_UI_PROTOCOL_HPP
+#define YF_COVER_UI_PROTOCOL_HPP
+
+#include <cmath>
+#include <cstdint>
+
+// ---- Message type identifiers ----
+
+enum YFCoverUIType : uint8_t {
+  Get_Version   = 0xB0,  ///< Version exchange / UI presence check (bidirectional)
+  Set_Buzzer    = 0xB1,  ///< Firmware → UI: control buzzer pattern
+  Set_LEDs      = 0xB2,  ///< Firmware → UI: update 18 LED states
+  Get_Button    = 0xB3,  ///< UI → Firmware: button press event
+  Get_Emergency = 0xB4,  ///< UI → Firmware: emergency button / sensor states (YardForce Cover UI)
+  Get_Rain      = 0xB5,  ///< UI → Firmware: rain sensor reading (YardForce Cover UI)
+  Get_Subscribe = 0xB6,  ///< UI → Firmware: subscribe to periodic data topics
+};
+
+// ---- LED identifiers (18 LEDs total) ----
+
+enum LED_id : uint8_t {
+  LED_CHARGING    = 0,   ///< Charging status indicator
+  LED_BATTERY_LOW = 1,   ///< Low battery warning
+  LED_POOR_GPS    = 2,   ///< Poor GPS quality indicator
+  LED_MOWER_LIFTED = 3,  ///< Mower lifted / emergency indicator
+  LED5  = 4,   // Battery bar segment 7 (lowest)
+  LED6  = 5,   // Battery bar segment 6
+  LED7  = 6,   // Battery bar segment 5
+  LED8  = 7,   // Battery bar segment 4
+  LED9  = 8,   // Battery bar segment 3
+  LED10 = 9,   // Battery bar segment 2
+  LED11 = 10,  // Battery bar segment 1 (highest)
+  LED_LOCK = 11,  ///< Lock indicator
+  LED_S2   = 12,  ///< Mode indicator S2
+  LED_S1   = 13,  ///< Mode indicator S1
+  LED15 = 14,  // GPS bar segment 1 (lowest)
+  LED16 = 15,  // GPS bar segment 2
+  LED17 = 16,  // GPS bar segment 3
+  LED18 = 17,  // GPS bar segment 4 (highest)
+};
+
+// ---- LED states (3 bits per LED, packed into 64-bit leds field) ----
+
+enum LED_state : uint8_t {
+  LED_off        = 0b000,
+  // 0b001..0b100 reserved
+  LED_blink_slow = 0b101,
+  LED_blink_fast = 0b110,
+  LED_on         = 0b111,
+};
+
+// ---- Emergency bitmask (msg_event_emergency.state) ----
+
+enum Emergency_state : uint8_t {
+  Emergency_latch = 0b00001,  ///< Latched emergency
+  Emergency_stop1 = 0b00010,  ///< Stop button 1
+  Emergency_stop2 = 0b00100,  ///< Stop button 2
+  Emergency_lift1 = 0b01000,  ///< Lift sensor / wheel lifted
+  Emergency_lift2 = 0b10000,  ///< Lift sensor 2 / extended lift detection
+};
+
+// ---- Topic subscription bitmask (msg_event_subscribe.topic_bitmask) ----
+
+enum Topic_state : uint8_t {
+  Topic_set_leds      = 1 << 0,  ///< Subscribe to LED update messages
+  Topic_set_ll_status = 1 << 1,  ///< Subscribe to low-level status messages
+  Topic_set_hl_state  = 1 << 2,  ///< Subscribe to high-level state messages
+};
+
+// ---- Message structures (packed, CRC-16 over all bytes except the crc field itself) ----
+
+#pragma pack(push, 1)
+
+struct msg_get_version {
+  uint8_t  type;      ///< YFCoverUIType::Get_Version
+  uint8_t  reserved;  ///< Padding
+  uint16_t version;   ///< Firmware version
+  uint16_t crc;       ///< CRC-16/CCITT
+};
+
+struct msg_set_buzzer {
+  uint8_t type;      ///< YFCoverUIType::Set_Buzzer
+  uint8_t repeat;    ///< Repeat count
+  uint8_t on_time;   ///< Signal on time (units defined by UI firmware)
+  uint8_t off_time;  ///< Signal off time
+  uint16_t crc;      ///< CRC-16/CCITT
+};
+
+/**
+ * @brief LED matrix update.
+ *
+ * Each of the 18 LEDs occupies 3 bits in the `leds` field:
+ *   bits [2:0]  = LED 0 (LED_CHARGING)
+ *   bits [5:3]  = LED 1 (LED_BATTERY_LOW)
+ *   ...
+ *   bits [53:51] = LED 17 (LED18)
+ *
+ * See LED_state for bit encoding.
+ */
+struct msg_set_leds {
+  uint8_t  type;      ///< YFCoverUIType::Set_LEDs
+  uint8_t  reserved;  ///< Padding
+  uint64_t leds;      ///< 18 × 3 bits of LED states
+  uint16_t crc;       ///< CRC-16/CCITT
+};
+
+struct msg_event_button {
+  uint8_t  type;            ///< YFCoverUIType::Get_Button
+  uint16_t button_id;       ///< Button identifier
+  uint8_t  press_duration;  ///< 0=single, 1=long, 2=very long
+  uint16_t crc;             ///< CRC-16/CCITT
+};
+
+struct msg_event_emergency {
+  uint8_t type;   ///< YFCoverUIType::Get_Emergency
+  uint8_t state;  ///< Bitmask, see Emergency_state
+  uint16_t crc;   ///< CRC-16/CCITT
+};
+
+struct msg_event_rain {
+  uint8_t  type;       ///< YFCoverUIType::Get_Rain
+  uint8_t  reserved;   ///< Padding
+  uint32_t value;      ///< Raw rain sensor ADC value
+  uint32_t threshold;  ///< Rain threshold (value < threshold → raining)
+  uint16_t crc;        ///< CRC-16/CCITT
+};
+
+struct msg_event_subscribe {
+  uint8_t  type;          ///< YFCoverUIType::Get_Subscribe
+  uint8_t  topic_bitmask; ///< Bitmask of topics to receive, see Topic_state
+  uint16_t interval;      ///< Update interval in ms
+  uint16_t crc;           ///< CRC-16/CCITT
+};
+
+#pragma pack(pop)
+
+// ---- LED helper functions ----
+
+/**
+ * @brief Set a single LED state in the leds bitmask.
+ * @param msg   The Set_LEDs message to modify.
+ * @param led   LED index (0–17), use LED_id enum.
+ * @param state LED state, use LED_state enum.
+ */
+inline void setLed(struct msg_set_leds& msg, int led, uint8_t state) {
+  uint64_t mask = ~(static_cast<uint64_t>(0b111) << (led * 3));
+  msg.leds &= mask;
+  msg.leds |= static_cast<uint64_t>(state & 0b111) << (led * 3);
+}
+
+/**
+ * @brief Set the 7-segment battery bar LEDs (LED5–LED11) based on a 0.0–1.0 value.
+ * @param msg   The Set_LEDs message to modify.
+ * @param value Battery fraction, 0.0 = empty, 1.0 = full.
+ */
+inline void setBars7(struct msg_set_leds& msg, double value) {
+  int on_leds = static_cast<int>(round(value * 7.0));
+  for (int i = 0; i < 7; i++) {
+    setLed(msg, LED11 - i, i < on_leds ? LED_on : LED_off);
+  }
+}
+
+/**
+ * @brief Set the 4-segment GPS bar LEDs (LED15–LED18) based on a 0.0–1.0 value.
+ * @param msg   The Set_LEDs message to modify.
+ * @param value GPS quality fraction, 0.0–1.0. Use a negative value to fast-blink all.
+ */
+inline void setBars4(struct msg_set_leds& msg, double value) {
+  if (value < 0.0) {
+    for (int i = 0; i < 4; i++) {
+      setLed(msg, LED15 + i, LED_blink_fast);
+    }
+  } else {
+    int on_leds = static_cast<int>(round(value * 4.0));
+    for (int i = 0; i < 4; i++) {
+      setLed(msg, LED18 - i, i < on_leds ? LED_on : LED_off);
+    }
+  }
+}
+
+#endif  // YF_COVER_UI_PROTOCOL_HPP


### PR DESCRIPTION
Implements the YardForce 500 front-panel Cover UI (yf_cover_ui) in the V2 firmware. The panel communicates via UART7 at 115200 baud using COBS packet framing and CRC-16/CCITT, ported from OpenMower/Firmware (original by Elmar Elflein).

New files:
- src/drivers/ui/yf_cover_ui/yf_cover_ui_protocol.hpp Protocol definitions: YFCoverUIType message types, LED_id/LED_state enums, Emergency_state bitmask, packed message structs, setLed/setBars4/setBars7 helper functions.
- src/drivers/ui/yf_cover_ui/yf_cover_ui.hpp YFCoverUI class declaration (extends InputDriver), YFCoverUIChannel enum with bit-7 button-flag encoding, channel helper functions.
- src/drivers/ui/yf_cover_ui/yf_cover_ui.cpp Driver implementation: ChibiOS thread, COBS encode/decode, CRC-16/CCITT via etl::crc16_ccitt, LED state built from power_service / high_level_service / emergency_service, emergency and button input forwarding to InputService.

Modified files:
- CMakeLists.txt: add yf_cover_ui.cpp to build
- boards/XCORE/mcuconf.h: switch UART7 from UARTDriver to SerialDriver
- robots/include/yardforce_robot.hpp: include yf_cover_ui.hpp, add yf_cover_ui_ member
- robots/src/yardforce_robot.cpp: register 'yf_cover_ui' driver and start it on SERIALD7
- src/drivers/input/input_driver.hpp: add yf_cover_ui union member to Input struct