### PR TITLE
ci: debug build on PR, release on main/tag + thread watermark log

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,9 @@ jobs:
         with:
           push: false
           context: .
+          # Debug build for pull requests, Release build for main / tagged releases.
+          build-args: |
+            BUILD_PRESET=${{ github.event_name == 'pull_request' && 'Debug' || 'Release' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=local,dest=./out

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -5,6 +5,8 @@
     <mapping directory="$PROJECT_DIR$/ext/littlefs" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ext/minmea" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ext/xbot_framework" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ext/xbot_framework/ext/cpputest" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ext/xbot_framework/ext/ulog" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/services" vcs="Git" />
   </component>
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         src/debug/debug_tcp_interface.cpp
         src/debug/debug_udp_interface.cpp
         src/debug/debuggable_driver.cpp
+        src/debug/thread_watermark.c
         robots/src/robot.cpp
         ${PLATFORM_SOURCES}
         ${LVGL_ASSETS_SRC}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ ENV CCACHE_NOHASHDIR="true"
 
 RUN pip install elf-size-analyze
 
+# Build preset to use for all platforms. CI passes "Debug" for pull requests and
+# "Release" for main / tagged releases.
+ARG BUILD_PRESET=Release
+
 COPY . /project
 
 WORKDIR /project
@@ -32,14 +36,14 @@ RUN mkdir build
 # deps like lwjson are fetched from GitHub once instead of once per platform
 # (avoids tripping codeload's transient 500s / rate limiting).
 ENV FETCHCONTENT_BASE_DIR=/project/build/_deps
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=YardForce -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BYardForce && cd YardForce && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=YardForce_V4 -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BYardForce_V4 && cd YardForce_V4 && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=Worx -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BWorx && cd Worx && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=Lyfco_E1600 -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BLyfco_E1600 && cd Lyfco_E1600 && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=Sabo -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BSabo && cd Sabo && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=xBot -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BxBot && cd xBot && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=Universal5S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal5S && cd Universal5S && make -j$(nproc)
-RUN cd build && cmake .. --preset=Release -DROBOT_PLATFORM=Universal7S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal7S && cd Universal7S && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=YardForce -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BYardForce && cd YardForce && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=YardForce_V4 -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BYardForce_V4 && cd YardForce_V4 && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Worx -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BWorx && cd Worx && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Lyfco_E1600 -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BLyfco_E1600 && cd Lyfco_E1600 && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Sabo -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BSabo && cd Sabo && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=xBot -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BxBot && cd xBot && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Universal5S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal5S && cd Universal5S && make -j$(nproc)
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Universal7S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal7S && cd Universal7S && make -j$(nproc)
 # Use Sabo build for RAM and ROM analysis for now - it has the most libraries
 RUN elf-size-analyze -H -R -t arm-none-eabi- ./build/Sabo/openmower.elf -W > build/ram-info.html
 RUN elf-size-analyze -H -F -t arm-none-eabi- ./build/Sabo/openmower.elf -W > build/flash-info.html

--- a/src/boot_service_discovery.cpp
+++ b/src/boot_service_discovery.cpp
@@ -19,6 +19,7 @@ static char boardAdvertisementRequestBuffer[100];
 static THD_WORKING_AREA(waServiceDiscovery, 512);
 
 static void multicast_sender_thread(void *p) {
+  chRegSetThreadName("ServiceDiscovery");
   (void)p;
   struct sockaddr_in multicast_addr;
   struct sockaddr_in addr;

--- a/src/debug/thread_watermark.c
+++ b/src/debug/thread_watermark.c
@@ -1,0 +1,66 @@
+//
+// Periodically logs the stack high-water mark (watermark) of every ChibiOS
+// thread. Only available in debug builds (requires CH_DBG_FILL_THREADS, which
+// fills each thread's working area with CH_DBG_STACK_FILL_VALUE on creation so
+// we can scan for the deepest stack usage).
+//
+
+#include "thread_watermark.h"
+
+#include "ch.h"
+#include "chdebug.h"
+
+#ifdef DEBUG_BUILD
+
+#include <ulog.h>
+
+// How often the watermark report is printed.
+#define WATERMARK_INTERVAL_MS 120000
+
+static THD_WORKING_AREA(watermark_wa, 512);
+
+// Returns the number of stack bytes that were never touched by the thread, by
+// counting the leading fill bytes from the bottom (low address) of the working
+// area. used = total - free.
+static size_t ThreadFreeStack(const thread_t *tp) {
+  const uint8_t *base = (const uint8_t *)chThdGetWorkingAreaX((thread_t *)tp);
+  // The thread_t structure lives at the top of the working area, so it marks
+  // the end of the usable stack region.
+  const uint8_t *end = (const uint8_t *)tp;
+  size_t free = 0;
+  while (base + free < end && base[free] == CH_DBG_STACK_FILL_VALUE) {
+    free++;
+  }
+  return free;
+}
+
+static THD_FUNCTION(WatermarkThread, arg) {
+  (void)arg;
+  chRegSetThreadName("watermark");
+
+  while (true) {
+    ULOG_INFO("=== Thread stack watermark ===");
+    thread_t *tp = chRegFirstThread();
+    while (tp != NULL) {
+      const uint8_t *base = (const uint8_t *)chThdGetWorkingAreaX(tp);
+      size_t total = (const uint8_t *)tp - base;
+      size_t free = ThreadFreeStack(tp);
+      const char *name = chRegGetThreadNameX(tp);
+      ULOG_INFO("%-12s stack: %4u/%4u used, %4u free", name != NULL ? name : "<unnamed>", (unsigned)(total - free),
+                (unsigned)total, (unsigned)free);
+      tp = chRegNextThread(tp);
+    }
+    chThdSleepMilliseconds(WATERMARK_INTERVAL_MS);
+  }
+}
+
+void InitThreadWatermark(void) {
+  chThdCreateStatic(watermark_wa, sizeof(watermark_wa), LOWPRIO, WatermarkThread, NULL);
+}
+
+#else  // !DEBUG_BUILD
+
+void InitThreadWatermark(void) {
+}
+
+#endif  // DEBUG_BUILD

--- a/src/debug/thread_watermark.c
+++ b/src/debug/thread_watermark.c
@@ -24,6 +24,9 @@ static THD_WORKING_AREA(watermark_wa, 512);
 // area. used = total - free.
 static size_t ThreadFreeStack(const thread_t *tp) {
   const uint8_t *base = (const uint8_t *)chThdGetWorkingAreaX((thread_t *)tp);
+#if PORT_ENABLE_GUARD_PAGES == TRUE
+  base += PORT_GUARD_PAGE_SIZE; /* skip the no-access guard region */
+#endif
   // The thread_t structure lives at the top of the working area, so it marks
   // the end of the usable stack region.
   const uint8_t *end = (const uint8_t *)tp;
@@ -38,11 +41,16 @@ static THD_FUNCTION(WatermarkThread, arg) {
   (void)arg;
   chRegSetThreadName("watermark");
 
+  chThdSleepMilliseconds(1000);
+
   while (true) {
     ULOG_INFO("=== Thread stack watermark ===");
     thread_t *tp = chRegFirstThread();
     while (tp != NULL) {
       const uint8_t *base = (const uint8_t *)chThdGetWorkingAreaX(tp);
+#if PORT_ENABLE_GUARD_PAGES == TRUE
+      base += PORT_GUARD_PAGE_SIZE; /* skip the no-access guard region */
+#endif
       size_t total = (const uint8_t *)tp - base;
       size_t free = ThreadFreeStack(tp);
       const char *name = chRegGetThreadNameX(tp);

--- a/src/debug/thread_watermark.h
+++ b/src/debug/thread_watermark.h
@@ -1,0 +1,19 @@
+//
+// Periodically logs the stack high-water mark (watermark) of every ChibiOS
+// thread. Only available in debug builds (requires CH_DBG_FILL_THREADS).
+//
+
+#ifndef THREAD_WATERMARK_H
+#define THREAD_WATERMARK_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Starts the background thread that periodically logs the per-thread stack
+// watermark. No-op unless built with DEBUG_BUILD.
+void InitThreadWatermark(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // THREAD_WATERMARK_H

--- a/src/drivers/gps/gps_driver.cpp
+++ b/src/drivers/gps/gps_driver.cpp
@@ -127,6 +127,7 @@ void GpsDriver::threadFunc() {
 }
 
 void GpsDriver::threadHelper(void *instance) {
+  chRegSetThreadName("GpsDriver");
   auto *gps_interface = static_cast<GpsDriver *>(instance);
   gps_interface->threadFunc();
 }

--- a/src/drivers/motor/vesc/VescDriver.cpp
+++ b/src/drivers/motor/vesc/VescDriver.cpp
@@ -350,6 +350,7 @@ void VescDriver::threadFunc() {
 }
 
 void VescDriver::threadHelper(void* instance) {
+  chRegSetThreadName("VescDriver");
   auto* i = static_cast<VescDriver*>(instance);
   i->threadFunc();
 }

--- a/src/drivers/motor/yfr4esc/YFR4escDriver.h
+++ b/src/drivers/motor/yfr4esc/YFR4escDriver.h
@@ -73,6 +73,7 @@ class YFR4escDriver : public DebuggableDriver, public MotorDriver {
 
   void threadFunc();
   static void threadHelper(void* instance) {
+    chRegSetThreadName("YFR4escDriver");
     static_cast<YFR4escDriver*>(instance)->threadFunc();
   };
 

--- a/src/drivers/ui/SaboCoverUI/sabo_cover_ui_controller.cpp
+++ b/src/drivers/ui/SaboCoverUI/sabo_cover_ui_controller.cpp
@@ -121,6 +121,7 @@ void SaboCoverUIController::Start() {
 }
 
 void SaboCoverUIController::ThreadHelper(void* instance) {
+  chRegSetThreadName("SaboCoverUICtrl");
   auto* i = static_cast<SaboCoverUIController*>(instance);
   i->ThreadFunc();
 }

--- a/src/drivers/ui/SaboCoverUI/sabo_cover_ui_display_driver_uc1698.hpp
+++ b/src/drivers/ui/SaboCoverUI/sabo_cover_ui_display_driver_uc1698.hpp
@@ -128,6 +128,7 @@ class SaboCoverUIDisplayDriverUC1698 {
   void SetWindowProgramAreaRaw(uint8_t t_x1, uint8_t t_x2, uint8_t t_y1, uint8_t t_y2, bool t_outside_mode = false);
 
   static void ThreadHelper(void* instance) {
+    chRegSetThreadName("SaboCoverUIDisp");
     auto* i = static_cast<SaboCoverUIDisplayDriverUC1698*>(instance);
     i->ThreadFunc();
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <xbot-service/RemoteLogging.hpp>
 #include <xbot-service/portable/system.hpp>
 
+#include "debug/thread_watermark.h"
 #include "globals.hpp"
 #include "heartbeat.h"
 #include "id_eeprom.h"
@@ -63,6 +64,8 @@ int main() {
   InitGlobals();
   InitHeartbeat();
   InitStatusLed();
+  // Debug-only: periodically log per-thread stack watermark (no-op in release).
+  InitThreadWatermark();
 
   SetStatusLedMode(LED_MODE_ON);
   SetStatusLedColor(RED);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,8 +64,6 @@ int main() {
   InitGlobals();
   InitHeartbeat();
   InitStatusLed();
-  // Debug-only: periodically log per-thread stack watermark (no-op in release).
-  InitThreadWatermark();
 
   SetStatusLedMode(LED_MODE_ON);
   SetStatusLedColor(RED);
@@ -91,6 +89,8 @@ int main() {
   // Safe to do before checking the carrier board, needed for logging
   xbot::service::system::initSystem();
   xbot::service::startRemoteLogging();
+  // Debug-only: periodically log per-thread stack watermark (no-op in release).
+  InitThreadWatermark();
 
   // Try opening the filesystem, on error fail
   if (!InitFS()) {


### PR DESCRIPTION
Pass BUILD_PRESET as Docker build arg, selected by CI: Debug for pull requests, Release for main and tagged releases.

Add a debug-only background thread that periodically logs the stack high-water mark of every ChibiOS thread (no-op in release builds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added debug-only per-thread stack watermark logging to help track stack usage during development.
  * Thread names are now registered at runtime for easier debugging across key worker threads/drivers.
* **Chores**
  * CI now selects the CMake build preset dynamically (Debug for pull requests; Release for main and tags).
  * Docker builds are parameterized with `BUILD_PRESET`, and the build setup includes the new debug monitoring source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->