### PR TITLE
Disable IP fragmentation code, since we never fragment. Move checksum…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         src/heartbeat.c
         src/id_eeprom.c
         src/boot_service_discovery.cpp
+        src/debug/checksum_test_interface.cpp
         src/json_stream.cpp
         src/services.cpp
         src/status_led.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         src/heartbeat.c
         src/id_eeprom.c
         src/boot_service_discovery.cpp
-        src/debug/checksum_test_interface.cpp
         src/json_stream.cpp
         src/services.cpp
         src/status_led.c

--- a/boards/XCORE/mcuconf.h
+++ b/boards/XCORE/mcuconf.h
@@ -319,7 +319,11 @@
 #define STM32_MAC_PHY_TIMEOUT               100
 #define STM32_MAC_ETH1_CHANGE_PHY_STATE     FALSE
 #define STM32_MAC_ETH1_IRQ_PRIORITY         13
-#define STM32_MAC_IP_CHECKSUM_OFFLOAD       0
+/* 3 = HW computes/inserts IP header + payload (TCP/UDP/ICMP) checksums incl.
+   pseudo-header on TX, and verifies them on RX (frames with bad IP/payload
+   checksum are dropped in the driver). Matching SW checksums are disabled in
+   cfg/lwipopts.h via the CHECKSUM_GEN and CHECKSUM_CHECK options. */
+#define STM32_MAC_IP_CHECKSUM_OFFLOAD       3
 
 /*
  * PWM driver system settings.

--- a/cfg/lwipopts.h
+++ b/cfg/lwipopts.h
@@ -52,7 +52,7 @@
  * allocation and deallocation.
  */
 #ifndef SYS_LIGHTWEIGHT_PROT
-#define SYS_LIGHTWEIGHT_PROT            0
+#define SYS_LIGHTWEIGHT_PROT            1
 #endif
 
 /** 

--- a/cfg/lwipopts.h
+++ b/cfg/lwipopts.h
@@ -517,8 +517,10 @@
  * this option does not affect outgoing packet sizes, which can be controlled
  * via IP_FRAG.
  */
+/* Disabled: no fragmented traffic expected, and HW checksum offload cannot
+   insert L4 checksums across IP fragments. See STM32_MAC_IP_CHECKSUM_OFFLOAD. */
 #ifndef IP_REASSEMBLY
-#define IP_REASSEMBLY                   1
+#define IP_REASSEMBLY                   0
 #endif
 
 /**
@@ -527,7 +529,7 @@
  * controlled via IP_REASSEMBLY.
  */
 #ifndef IP_FRAG
-#define IP_FRAG                         1
+#define IP_FRAG                         0
 #endif
 
 /**
@@ -1784,50 +1786,54 @@
 /**
  * CHECKSUM_GEN_IP==1: Generate checksums in software for outgoing IP packets.
  */
+/* HW checksum offload: STM32H7 ETH DMA inserts this checksum on TX
+   (STM32_MAC_IP_CHECKSUM_OFFLOAD=3 in mcuconf.h). */
 #ifndef CHECKSUM_GEN_IP
-#define CHECKSUM_GEN_IP                 1
+#define CHECKSUM_GEN_IP                 0
 #endif
  
 /**
  * CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.
  */
 #ifndef CHECKSUM_GEN_UDP
-#define CHECKSUM_GEN_UDP                1
+#define CHECKSUM_GEN_UDP                0
 #endif
  
 /**
  * CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.
  */
 #ifndef CHECKSUM_GEN_TCP
-#define CHECKSUM_GEN_TCP                1
+#define CHECKSUM_GEN_TCP                0
 #endif
 
 /**
  * CHECKSUM_GEN_ICMP==1: Generate checksums in software for outgoing ICMP packets.
  */
 #ifndef CHECKSUM_GEN_ICMP
-#define CHECKSUM_GEN_ICMP               1
+#define CHECKSUM_GEN_ICMP               0
 #endif
  
 /**
  * CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.
  */
+/* HW checksum offload: STM32H7 ETH DMA verifies RX checksums; the MAC driver
+   drops frames flagged with IPHE/IPCE before they reach lwIP. */
 #ifndef CHECKSUM_CHECK_IP
-#define CHECKSUM_CHECK_IP               1
+#define CHECKSUM_CHECK_IP               0
 #endif
  
 /**
  * CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.
  */
 #ifndef CHECKSUM_CHECK_UDP
-#define CHECKSUM_CHECK_UDP              1
+#define CHECKSUM_CHECK_UDP              0
 #endif
 
 /**
  * CHECKSUM_CHECK_TCP==1: Check checksums in software for incoming TCP packets.
  */
 #ifndef CHECKSUM_CHECK_TCP
-#define CHECKSUM_CHECK_TCP              1
+#define CHECKSUM_CHECK_TCP              0
 #endif
 
 /**

--- a/cfg/lwipopts.h
+++ b/cfg/lwipopts.h
@@ -1837,6 +1837,13 @@
 #endif
 
 /**
+ * CHECKSUM_CHECK_ICMP==1: Check checksums in software for incoming ICMP packets.
+ */
+#ifndef CHECKSUM_CHECK_ICMP
+#define CHECKSUM_CHECK_ICMP            0
+#endif
+
+/**
  * LWIP_CHECKSUM_ON_COPY==1: Calculate checksum when copying data from
  * application buffers to pbufs.
  */

--- a/ext/ChibiOS_21.11.3/os/hal/ports/STM32/LLD/MACv2/hal_mac_lld.c
+++ b/ext/ChibiOS_21.11.3/os/hal/ports/STM32/LLD/MACv2/hal_mac_lld.c
@@ -592,9 +592,24 @@ msg_t mac_lld_get_receive_descriptor(MACDriver *macp,
 
       return MSG_OK;
     }
-    /* Invalid frame found, purging.*/
+    /* Invalid frame found (RX error, address filtered, or failed HW
+       checksum), purging: hand the buffer back to the DMA and keep the
+       ring index in lockstep with the DMA write pointer. Failing to
+       advance here desyncs rdindex from the DMA and stalls RX after the
+       first discarded frame. Caller (macWaitReceiveDescriptor) already
+       holds the system lock, so no osalSysLock here.*/
     rdes->rdes3 = STM32_RDES3_OWN | STM32_RDES3_IOC | STM32_RDES3_BUF1V;
+    __DSB();
+    /* If the DMA engine is stalled then a restart request is issued.*/
+    if ((ETH->DMADSR & ETH_DMADSR_RPS) == ETH_DMADSR_RPS_SUSPENDED) {
+      ETH->DMACSR = ETH_DMACSR_RBU;
+    }
+    ETH->DMACRDTPR = 0U;
     /* Reposition in ring.*/
+    macp->rdindex++;
+    if (macp->rdindex >= STM32_MAC_RECEIVE_BUFFERS)
+      macp->rdindex = 0U;
+    rdes = (stm32_eth_rx_descriptor_t *)&__eth_rd[macp->rdindex];
   }
 
   return MSG_TIMEOUT;

--- a/src/debug/checksum_test_interface.cpp
+++ b/src/debug/checksum_test_interface.cpp
@@ -1,0 +1,157 @@
+//
+// Created for network corruption / checksum testing.
+//
+
+#include "checksum_test_interface.hpp"
+
+// clang-format off
+#include "ch.h"
+#include "hal.h"
+// clang-format on
+
+#include <cstddef>
+#include <cstring>
+
+#include "lwip/sockets.h"
+#include "ulog.h"
+
+namespace {
+
+// Wire format. All fields little-endian (host is little-endian Cortex-M7, and
+// the Linux test tool matches). __attribute__((packed)) to avoid padding.
+constexpr uint32_t kTestMagic = 0x54534554;   // "TEST"
+constexpr uint32_t kReplyMagic = 0x504C5052;  // "RPLP"
+
+struct TestHeader {
+  uint32_t magic;
+  uint32_t test_id;
+  uint32_t declared_len;  // expected payload length in bytes
+  uint32_t crc32;         // CRC32 (IEEE) over the whole packet except this field
+} __attribute__((packed));
+
+struct ReplyHeader {
+  uint32_t magic;
+  uint32_t test_id;
+  uint32_t verdict;             // Verdict enum
+  uint32_t received_total_len;  // full datagram length as seen by recvfrom
+  uint32_t computed_crc;        // CRC32 the firmware computed over the payload
+} __attribute__((packed));
+
+enum Verdict : uint32_t {
+  VERDICT_OK = 0,
+  VERDICT_BAD_MAGIC = 1,
+  VERDICT_LEN_MISMATCH = 2,
+  VERDICT_CRC_MISMATCH = 3,
+  VERDICT_TOO_SHORT = 4,
+};
+
+// Standard reflected CRC32 (IEEE 802.3, poly 0xEDB88320), matching Python's
+// binascii.crc32 / zlib.crc32. Computed without a table to keep things small.
+// Streaming form: pass the running register in/out so a CRC can span multiple
+// non-contiguous regions. Seed with 0xFFFFFFFF and finalise with ~crc.
+uint32_t Crc32Feed(uint32_t crc, const uint8_t *data, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    crc ^= data[i];
+    for (int bit = 0; bit < 8; bit++) {
+      uint32_t mask = -(crc & 1u);
+      crc = (crc >> 1) ^ (0xEDB88320u & mask);
+    }
+  }
+  return crc;
+}
+
+const char *VerdictName(uint32_t v) {
+  switch (v) {
+    case VERDICT_OK: return "OK";
+    case VERDICT_BAD_MAGIC: return "BAD_MAGIC";
+    case VERDICT_LEN_MISMATCH: return "LEN_MISMATCH";
+    case VERDICT_CRC_MISMATCH: return "CRC_MISMATCH";
+    case VERDICT_TOO_SHORT: return "TOO_SHORT";
+    default: return "UNKNOWN";
+  }
+}
+
+// Receive buffer is intentionally larger than xbot::config::max_packet_size
+// (1500) so that oversize / truncation behaviour is observable here instead of
+// being silently clipped like the production path.
+uint8_t rx_buffer[2048];
+
+THD_WORKING_AREA(waChecksumTest, 2048);
+
+void ChecksumTestThread(void *) {
+  chRegSetThreadName("ChecksumTest");
+
+  int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sockfd < 0) {
+    ULOG_ERROR("ChecksumTest: socket creation failed");
+    return;
+  }
+
+  struct sockaddr_in server_addr;
+  memset(&server_addr, 0, sizeof(server_addr));
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  server_addr.sin_port = htons(CHECKSUM_TEST_PORT);
+
+  if (bind(sockfd, reinterpret_cast<struct sockaddr *>(&server_addr), sizeof(server_addr)) < 0) {
+    ULOG_ERROR("ChecksumTest: bind to port %u failed", CHECKSUM_TEST_PORT);
+    lwip_close(sockfd);
+    return;
+  }
+
+  ULOG_INFO("ChecksumTest: listening on UDP port %u", CHECKSUM_TEST_PORT);
+
+  struct sockaddr_in client_addr;
+  socklen_t client_len = sizeof(client_addr);
+
+  while (true) {
+    const int received = recvfrom(sockfd, rx_buffer, sizeof(rx_buffer), 0,
+                                  reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+    if (received < 0) {
+      continue;
+    }
+
+    ReplyHeader reply;
+    reply.magic = kReplyMagic;
+    reply.received_total_len = static_cast<uint32_t>(received);
+    reply.computed_crc = 0;
+    reply.test_id = 0;
+    reply.verdict = VERDICT_TOO_SHORT;
+
+    if (static_cast<size_t>(received) >= sizeof(TestHeader)) {
+      TestHeader hdr;
+      memcpy(&hdr, rx_buffer, sizeof(hdr));
+      reply.test_id = hdr.test_id;
+
+      const size_t payload_len = static_cast<size_t>(received) - sizeof(TestHeader);
+      // CRC covers the whole packet except the crc32 field itself: the header
+      // bytes before the field, then the payload after the header.
+      uint32_t crc = 0xFFFFFFFFu;
+      crc = Crc32Feed(crc, rx_buffer, offsetof(TestHeader, crc32));
+      crc = Crc32Feed(crc, rx_buffer + sizeof(TestHeader), payload_len);
+      crc = ~crc;
+      reply.computed_crc = crc;
+
+      if (hdr.magic != kTestMagic) {
+        reply.verdict = VERDICT_BAD_MAGIC;
+      } else if (hdr.declared_len != payload_len) {
+        reply.verdict = VERDICT_LEN_MISMATCH;
+      } else if (hdr.crc32 != crc) {
+        reply.verdict = VERDICT_CRC_MISMATCH;
+      } else {
+        reply.verdict = VERDICT_OK;
+      }
+    }
+
+    ULOG_INFO("ChecksumTest: id=%u len=%d verdict=%s", reply.test_id, received, VerdictName(reply.verdict));
+
+    sendto(sockfd, &reply, sizeof(reply), 0, reinterpret_cast<struct sockaddr *>(&client_addr), client_len);
+  }
+}
+
+}  // namespace
+
+void InitChecksumTestInterface() {
+  thread_t *tp = chThdCreateStatic(waChecksumTest, sizeof(waChecksumTest), NORMALPRIO, ChecksumTestThread, nullptr);
+  tp->name = "ChecksumTest";
+}

--- a/src/debug/checksum_test_interface.hpp
+++ b/src/debug/checksum_test_interface.hpp
@@ -1,0 +1,22 @@
+//
+// Corruption / checksum test interface.
+//
+// Opens a UDP socket and validates incoming test packets, replying with a
+// verdict. Used together with tools/net_corruption_test/send_corrupt.py to
+// characterise whether the network stack (lwIP + MAC) drops or delivers
+// corrupted packets. See that script for the wire format and test cases.
+//
+
+#ifndef CHECKSUM_TEST_INTERFACE_HPP
+#define CHECKSUM_TEST_INTERFACE_HPP
+
+#include <cstdint>
+
+// UDP port the firmware listens on for corruption test packets.
+static constexpr uint16_t CHECKSUM_TEST_PORT = 4500;
+
+// Starts the checksum test thread. Safe to call once after the network stack
+// (xbot::service::Io::start()) is up.
+void InitChecksumTestInterface();
+
+#endif  // CHECKSUM_TEST_INTERFACE_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,7 +126,6 @@ int main() {
 
   robot->InitPlatform();
   xbot::service::Io::start();
-  InitChecksumTestInterface();
   StartServices();
   SetStatusLedColor(GREEN);
   DispatchEvents();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include <xbot-service/RemoteLogging.hpp>
 #include <xbot-service/portable/system.hpp>
 
+#include "debug/checksum_test_interface.hpp"
 #include "debug/thread_watermark.h"
 #include "globals.hpp"
 #include "heartbeat.h"
@@ -125,6 +126,7 @@ int main() {
 
   robot->InitPlatform();
   xbot::service::Io::start();
+  InitChecksumTestInterface();
   StartServices();
   SetStatusLedColor(GREEN);
   DispatchEvents();

--- a/tools/net_corruption_test/README.md
+++ b/tools/net_corruption_test/README.md
@@ -1,0 +1,67 @@
+# Network corruption / checksum test
+
+Characterises whether the firmware's network stack (lwIP + STM32 MAC) drops or
+delivers corrupted UDP packets. Use it to capture a **baseline** of the current
+software-checksum implementation, then re-run after enabling hardware
+checksumming and the D-cache to confirm nothing regresses.
+
+## Pieces
+
+- `send_corrupt.py` — Linux host tool. Crafts raw IP+UDP packets with specific
+  corruptions and checks the verdict the firmware replies with.
+- Firmware side: `src/debug/checksum_test_interface.cpp`, a thread bound to UDP
+  port **4500**. It validates each packet (magic / declared length / CRC32) and
+  replies with a verdict. It also logs each result via `ULOG_INFO`.
+
+## Wire format (little-endian uint32 fields)
+
+```
+request: magic("TEST") | test_id | declared_len | crc32 | payload[declared_len]
+reply:   magic("RPLP") | test_id | verdict | received_total_len | computed_crc
+```
+
+`crc32` covers the whole packet except the crc32 field itself:
+`CRC32(magic || test_id || declared_len || payload)`, so corruption in either
+the header fields or the payload is detected.
+
+`verdict`: 0=OK 1=BAD_MAGIC 2=LEN_MISMATCH 3=CRC_MISMATCH 4=TOO_SHORT.
+No reply at all = the stack dropped the packet (expected for bad checksums).
+
+## Running
+
+Needs root for raw sockets:
+
+```
+sudo ./send_corrupt.py <firmware_ip>
+sudo ./send_corrupt.py <firmware_ip> --only bad_ip_csum   # single case
+```
+
+Source IP, egress interface and firmware MAC are auto-detected; override with
+`--src-ip` / `--iface` / `--dst-mac`. The tool listens for replies on
+`--src-port` (default 54321).
+
+Packets are injected at **layer 2** (`AF_PACKET`), not via an `IP_HDRINCL` raw
+socket. This matters: an `IP_HDRINCL` socket lets the host kernel recompute the
+IP header checksum (and NIC TX offload can rewrite IP/UDP checksums), which
+would silently "fix" the corruptions we are trying to test — in particular
+`bad_ip_csum`. Sending the full Ethernet frame ourselves puts the bytes on the
+wire verbatim.
+
+## Test cases and expected outcome (current, software-checksum config)
+
+| case | what it sends | expected |
+|------|----------------|----------|
+| `baseline` | fully valid packet | `OK` |
+| `bad_udp_csum` | valid payload, corrupted UDP checksum | `DROP` (CHECKSUM_CHECK_UDP) |
+| `udp_csum_zero_bad_payload` | UDP checksum 0 + corrupted payload | `CRC_MISMATCH` — the hole: lwIP skips the check |
+| `bad_ip_csum` | corrupted IP header checksum | `DROP` (CHECKSUM_CHECK_IP) |
+| `valid_csum_bad_payload` | payload ≠ crc field, UDP checksum valid | `CRC_MISMATCH` — app CRC catches it |
+| `len_field_lie` | declared_len ≠ actual length | `LEN_MISMATCH` |
+| `bad_magic` | wrong magic | `BAD_MAGIC` |
+| `large_within_mtu` | 1400-byte payload, under MTU | `OK` |
+| `max_packet_size` | UDP payload = `max_packet_size` (1472); IP total exactly 1500, single frame | `OK` (rx_len=1472) |
+| `fragmented` | 1600-byte payload, IP-fragmented | `OK` (reassembly) |
+
+When hardware checksum offload is later enabled, watch especially
+`udp_csum_zero_bad_payload` and `fragmented` — those are where the MAC's L4
+offload behaviour differs from software checks.

--- a/tools/net_corruption_test/README.md
+++ b/tools/net_corruption_test/README.md
@@ -1,9 +1,10 @@
 # Network corruption / checksum test
 
 Characterises whether the firmware's network stack (lwIP + STM32 MAC) drops or
-delivers corrupted UDP packets. Use it to capture a **baseline** of the current
-software-checksum implementation, then re-run after enabling hardware
-checksumming and the D-cache to confirm nothing regresses.
+delivers corrupted UDP packets. The current config offloads RX checksum
+verification to the STM32H7 ETH DMA (software checks disabled in `lwipopts.h`)
+and disables IP reassembly. Use it to confirm corrupted packets are still
+dropped and nothing regresses.
 
 ## Pieces
 
@@ -12,6 +13,8 @@ checksumming and the D-cache to confirm nothing regresses.
 - Firmware side: `src/debug/checksum_test_interface.cpp`, a thread bound to UDP
   port **4500**. It validates each packet (magic / declared length / CRC32) and
   replies with a verdict. It also logs each result via `ULOG_INFO`.
+  Opt-in only: build the firmware with `-DENABLE_CHECKSUM_TEST_INTERFACE` to
+  compile it in. It is not present in normal firmware (not even debug builds).
 
 ## Wire format (little-endian uint32 fields)
 
@@ -47,21 +50,17 @@ would silently "fix" the corruptions we are trying to test — in particular
 `bad_ip_csum`. Sending the full Ethernet frame ourselves puts the bytes on the
 wire verbatim.
 
-## Test cases and expected outcome (current, software-checksum config)
+## Test cases and expected outcome (current, HW-offload config)
 
 | case | what it sends | expected |
 |------|----------------|----------|
 | `baseline` | fully valid packet | `OK` |
-| `bad_udp_csum` | valid payload, corrupted UDP checksum | `DROP` (CHECKSUM_CHECK_UDP) |
-| `udp_csum_zero_bad_payload` | UDP checksum 0 + corrupted payload | `CRC_MISMATCH` — the hole: lwIP skips the check |
-| `bad_ip_csum` | corrupted IP header checksum | `DROP` (CHECKSUM_CHECK_IP) |
+| `bad_udp_csum` | valid payload, corrupted UDP checksum | `DROP` (MAC L4 offload) |
+| `udp_csum_zero_bad_payload` | UDP checksum 0 + corrupted payload | `CRC_MISMATCH` — the hole: checksum 0 skips the check |
+| `bad_ip_csum` | corrupted IP header checksum | `DROP` (MAC L3 offload) |
 | `valid_csum_bad_payload` | payload ≠ crc field, UDP checksum valid | `CRC_MISMATCH` — app CRC catches it |
 | `len_field_lie` | declared_len ≠ actual length | `LEN_MISMATCH` |
 | `bad_magic` | wrong magic | `BAD_MAGIC` |
 | `large_within_mtu` | 1400-byte payload, under MTU | `OK` |
 | `max_packet_size` | UDP payload = `max_packet_size` (1472); IP total exactly 1500, single frame | `OK` (rx_len=1472) |
-| `fragmented` | 1600-byte payload, IP-fragmented | `OK` (reassembly) |
-
-When hardware checksum offload is later enabled, watch especially
-`udp_csum_zero_bad_payload` and `fragmented` — those are where the MAC's L4
-offload behaviour differs from software checks.
+| `fragmented` | 1600-byte payload, IP-fragmented | `DROP` — IP reassembly is disabled |

--- a/tools/net_corruption_test/send_corrupt.py
+++ b/tools/net_corruption_test/send_corrupt.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+Network corruption / checksum test tool.
+
+Sends hand-crafted UDP packets (raw socket, full IP+UDP control) to the
+firmware's checksum test thread and checks the verdict it replies with. Used to
+characterise whether the network stack (lwIP + STM32 MAC) drops or delivers
+corrupted packets, before and after enabling hardware checksumming / D-cache.
+
+Wire format must match src/debug/checksum_test_interface.cpp:
+
+  request  payload: magic("TEST") | test_id | declared_len | crc32 | payload[declared_len]
+  reply    payload: magic("RPLP") | test_id | verdict | received_total_len | computed_crc
+
+  all fields little-endian uint32.
+
+Requires root (raw sockets):  sudo ./send_corrupt.py <firmware_ip>
+"""
+
+import argparse
+import binascii
+import fcntl
+import socket
+import struct
+import sys
+import time
+
+TEST_PORT = 4500
+TEST_MAGIC = 0x54534554  # "TEST"
+REPLY_MAGIC = 0x504C5052  # "RPLP"
+
+TEST_HEADER_LEN = 16  # magic + test_id + declared_len + crc32
+# Must match xbot::config::max_packet_size: the largest UDP payload that fits a
+# single unfragmented Ethernet frame, MTU(1500) - IP(20) - UDP(8).
+MAX_PACKET_SIZE = 1472
+
+VERDICT_NAMES = {
+    0: "OK",
+    1: "BAD_MAGIC",
+    2: "LEN_MISMATCH",
+    3: "CRC_MISMATCH",
+    4: "TOO_SHORT",
+}
+DROP = "DROP"  # expected outcome: stack swallows the packet, no reply
+
+
+# ---------------------------------------------------------------------------
+# checksum helpers
+# ---------------------------------------------------------------------------
+def inet_checksum(data: bytes) -> int:
+    """Standard 16-bit one's-complement Internet checksum (RFC 1071)."""
+    if len(data) % 2:
+        data += b"\x00"
+    total = 0
+    for i in range(0, len(data), 2):
+        total += (data[i] << 8) | data[i + 1]
+    total = (total & 0xFFFF) + (total >> 16)
+    total = (total & 0xFFFF) + (total >> 16)
+    return (~total) & 0xFFFF
+
+
+def build_ip_header(src_ip, dst_ip, payload_len, ident, *, frag_off=0, mf=False, bad_csum=False):
+    ver_ihl = (4 << 4) | 5
+    tos = 0
+    total_len = 20 + payload_len
+    flags_frag = ((0x1 if mf else 0x0) << 13) | (frag_off & 0x1FFF)
+    ttl = 64
+    proto = socket.IPPROTO_UDP
+    src = socket.inet_aton(src_ip)
+    dst = socket.inet_aton(dst_ip)
+
+    hdr = struct.pack("!BBHHHBBH4s4s", ver_ihl, tos, total_len, ident,
+                      flags_frag, ttl, proto, 0, src, dst)
+    csum = inet_checksum(hdr)
+    if bad_csum:
+        csum ^= 0xFFFF  # guaranteed-wrong value
+    hdr = struct.pack("!BBHHHBBH4s4s", ver_ihl, tos, total_len, ident,
+                      flags_frag, ttl, proto, csum, src, dst)
+    return hdr
+
+
+def build_udp(src_ip, dst_ip, src_port, dst_port, udp_payload, *, csum_mode="correct"):
+    length = 8 + len(udp_payload)
+    hdr = struct.pack("!HHHH", src_port, dst_port, length, 0)
+    if csum_mode == "zero":
+        csum = 0
+    else:
+        pseudo = socket.inet_aton(src_ip) + socket.inet_aton(dst_ip) + \
+                 struct.pack("!BBH", 0, socket.IPPROTO_UDP, length)
+        csum = inet_checksum(pseudo + hdr + udp_payload)
+        if csum == 0:
+            csum = 0xFFFF  # 0 means "no checksum"; never emit it for a real one
+        if csum_mode == "bad":
+            csum ^= 0xFFFF
+    return struct.pack("!HHHH", src_port, dst_port, length, csum) + udp_payload
+
+
+def make_test_payload(test_id, payload, *, declared_len=None, crc_payload=None, magic=TEST_MAGIC):
+    """Build the application-layer test packet (header + payload).
+
+    The crc32 field covers the whole packet except the field itself:
+    CRC32(magic || test_id || declared_len || payload). crc_payload overrides
+    the bytes fed into the CRC (used to send a stale CRC over a mutated payload).
+    """
+    if declared_len is None:
+        declared_len = len(payload)
+    crc_body = payload if crc_payload is None else crc_payload
+    crc_input = struct.pack("<III", magic, test_id, declared_len) + crc_body
+    crc = binascii.crc32(crc_input) & 0xFFFFFFFF
+    header = struct.pack("<IIII", magic, test_id, declared_len, crc)
+    return header + payload
+
+
+def pattern(n):
+    return bytes(i & 0xFF for i in range(n))
+
+
+# ---------------------------------------------------------------------------
+# test cases
+# ---------------------------------------------------------------------------
+# Each builder returns a list of raw IP packets (bytes) to send on the wire.
+# Most cases are a single packet; fragmentation returns two.
+def case_baseline(ctx):
+    tp = make_test_payload(ctx.test_id, pattern(64))
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_bad_udp_csum(ctx):
+    tp = make_test_payload(ctx.test_id, pattern(64))
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp, csum_mode="bad")
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_udp_csum_zero_bad_payload(ctx):
+    # UDP checksum disabled (0); payload corrupted but crc field NOT updated.
+    good = pattern(64)
+    corrupt = bytearray(good)
+    corrupt[10] ^= 0xFF
+    tp = make_test_payload(ctx.test_id, bytes(corrupt), crc_payload=good)
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp, csum_mode="zero")
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_bad_ip_csum(ctx):
+    tp = make_test_payload(ctx.test_id, pattern(64))
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident, bad_csum=True) + udp]
+
+
+def case_valid_csum_bad_payload(ctx):
+    # Payload differs from what the crc field claims, but UDP checksum is valid
+    # for the bytes on the wire -> stack delivers, app-layer CRC must catch it.
+    good = pattern(64)
+    corrupt = bytearray(good)
+    corrupt[20] ^= 0xFF
+    tp = make_test_payload(ctx.test_id, bytes(corrupt), crc_payload=good)
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_len_field_lie(ctx):
+    # declared_len says 100, but only 50 payload bytes are actually sent.
+    payload = pattern(50)
+    tp = make_test_payload(ctx.test_id, payload, declared_len=100)
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_bad_magic(ctx):
+    tp = make_test_payload(ctx.test_id, pattern(64), magic=0xDEADBEEF)
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_large_within_mtu(ctx):
+    # Total IP packet stays under 1500: 1400 payload + headers.
+    tp = make_test_payload(ctx.test_id, pattern(1400))
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_max_packet_size(ctx):
+    # Exactly xbot::config::max_packet_size of UDP payload. This is the largest
+    # packet that fits a single, unfragmented Ethernet frame:
+    #   UDP payload  = MAX_PACKET_SIZE (1472)
+    #   IP total     = 20 + 8 + 1472 = 1500 = MTU  -> one frame, no fragmentation
+    app_payload = MAX_PACKET_SIZE - TEST_HEADER_LEN
+    tp = make_test_payload(ctx.test_id, pattern(app_payload))
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+    assert len(udp) - 8 == MAX_PACKET_SIZE  # UDP payload == max_packet_size
+    return [build_ip_header(ctx.src_ip, ctx.dst_ip, len(udp), ctx.ident) + udp]
+
+
+def case_fragmented(ctx):
+    # Build one big UDP datagram, then IP-fragment it into two on-wire fragments.
+    # Tests reassembly (and, after HW checksum is enabled, whether the MAC's
+    # L4 offload copes with fragments).
+    tp = make_test_payload(ctx.test_id, pattern(1600))
+    udp = build_udp(ctx.src_ip, ctx.dst_ip, ctx.src_port, TEST_PORT, tp)
+
+    # Split the UDP datagram. IP fragment offsets count in 8-byte units, so the
+    # first fragment's payload length must be a multiple of 8.
+    split = 1480  # multiple of 8, fits in MTU with 20-byte IP header
+    frag1 = udp[:split]
+    frag2 = udp[split:]
+    pkts = [
+        build_ip_header(ctx.src_ip, ctx.dst_ip, len(frag1), ctx.ident, frag_off=0, mf=True) + frag1,
+        build_ip_header(ctx.src_ip, ctx.dst_ip, len(frag2), ctx.ident, frag_off=split // 8, mf=False) + frag2,
+    ]
+    return pkts
+
+
+TEST_CASES = [
+    ("baseline", case_baseline, "OK"),
+    ("bad_udp_csum", case_bad_udp_csum, DROP),
+    ("udp_csum_zero_bad_payload", case_udp_csum_zero_bad_payload, "CRC_MISMATCH"),
+    ("bad_ip_csum", case_bad_ip_csum, DROP),
+    ("valid_csum_bad_payload", case_valid_csum_bad_payload, "CRC_MISMATCH"),
+    ("len_field_lie", case_len_field_lie, "LEN_MISMATCH"),
+    ("bad_magic", case_bad_magic, "BAD_MAGIC"),
+    ("large_within_mtu", case_large_within_mtu, "OK"),
+    ("max_packet_size", case_max_packet_size, "OK"),
+    ("fragmented", case_fragmented, DROP),
+]
+
+
+# ---------------------------------------------------------------------------
+# runner
+# ---------------------------------------------------------------------------
+class Ctx:
+    def __init__(self, src_ip, dst_ip, src_port, test_id, ident):
+        self.src_ip = src_ip
+        self.dst_ip = dst_ip
+        self.src_port = src_port
+        self.test_id = test_id
+        self.ident = ident
+
+
+def detect_src_ip(dst_ip):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect((dst_ip, TEST_PORT))
+        return s.getsockname()[0]
+    finally:
+        s.close()
+
+
+# --- L2 (AF_PACKET) helpers -------------------------------------------------
+# We send at layer 2 so the host kernel does not "fix up" our deliberately bad
+# IP/UDP checksums (IP_HDRINCL raw sockets let the kernel recompute the IP
+# header checksum, and NIC TX offload can rewrite both). AF_PACKET SOCK_RAW
+# transmits the frame verbatim.
+SIOCGIFADDR = 0x8915
+SIOCGIFHWADDR = 0x8927
+ETH_P_IP = 0x0800
+
+
+def _ifreq(ifname):
+    return struct.pack("256s", ifname.encode()[:15])
+
+
+def get_if_addr(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        return socket.inet_ntoa(fcntl.ioctl(s.fileno(), SIOCGIFADDR, _ifreq(ifname))[20:24])
+    finally:
+        s.close()
+
+
+def get_if_hwaddr(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        return fcntl.ioctl(s.fileno(), SIOCGIFHWADDR, _ifreq(ifname))[18:24]
+    finally:
+        s.close()
+
+
+def find_iface_for_ip(src_ip):
+    for _, name in socket.if_nameindex():
+        try:
+            if get_if_addr(name) == src_ip:
+                return name
+        except OSError:
+            continue
+    raise RuntimeError(f"no interface found for source IP {src_ip}")
+
+
+def resolve_dst_mac(dst_ip):
+    # Prime the ARP cache with a throwaway datagram, then read /proc/net/arp.
+    p = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        p.sendto(b"\x00", (dst_ip, 9))  # discard port
+    except OSError:
+        pass
+    finally:
+        p.close()
+    for _ in range(20):
+        with open("/proc/net/arp") as f:
+            for line in f.read().splitlines()[1:]:
+                cols = line.split()
+                if cols and cols[0] == dst_ip and cols[3] != "00:00:00:00:00:00":
+                    return bytes(int(x, 16) for x in cols[3].split(":"))
+        time.sleep(0.1)
+    raise RuntimeError(f"could not resolve MAC for {dst_ip} (is it reachable?)")
+
+
+def mac_str(mac):
+    return ":".join(f"{b:02x}" for b in mac)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Send corrupted UDP packets to the firmware checksum tester.")
+    ap.add_argument("dst_ip", help="firmware IP address")
+    ap.add_argument("--src-ip", help="source IP to use (default: auto-detect)")
+    ap.add_argument("--iface", help="egress interface (default: auto-detect from src IP)")
+    ap.add_argument("--dst-mac", help="firmware MAC aa:bb:.. (default: resolve via ARP)")
+    ap.add_argument("--src-port", type=int, default=54321, help="source UDP port (reply listener)")
+    ap.add_argument("--timeout", type=float, default=1.0, help="seconds to wait for a reply")
+    ap.add_argument("--only", help="run only the named test case")
+    args = ap.parse_args()
+
+    src_ip = args.src_ip or detect_src_ip(args.dst_ip)
+    iface = args.iface or find_iface_for_ip(src_ip)
+    src_mac = get_if_hwaddr(iface)
+    if args.dst_mac:
+        dst_mac = bytes(int(x, 16) for x in args.dst_mac.split(":"))
+    else:
+        dst_mac = resolve_dst_mac(args.dst_ip)
+    eth_hdr = dst_mac + src_mac + struct.pack("!H", ETH_P_IP)
+
+    print(f"iface {iface}  src {src_ip}:{args.src_port} ({mac_str(src_mac)})")
+    print(f"  ->  dst {args.dst_ip}:{TEST_PORT} ({mac_str(dst_mac)})\n")
+
+    try:
+        raw = socket.socket(socket.AF_PACKET, socket.SOCK_RAW)
+        raw.bind((iface, 0))
+    except PermissionError:
+        sys.exit("AF_PACKET socket needs root: run with sudo")
+
+    rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    rx.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    rx.bind((src_ip, args.src_port))
+    rx.settimeout(args.timeout)
+
+    passed = failed = 0
+    for test_id, (name, builder, expected) in enumerate(TEST_CASES, start=1):
+        if args.only and name != args.only:
+            continue
+        ctx = Ctx(src_ip, args.dst_ip, args.src_port, test_id, ident=0x4000 + test_id)
+
+        # Drain any stale replies.
+        rx.setblocking(False)
+        try:
+            while True:
+                rx.recv(2048)
+        except (BlockingIOError, socket.error):
+            pass
+        rx.setblocking(True)
+        rx.settimeout(args.timeout)
+
+        for pkt in builder(ctx):
+            frame = eth_hdr + pkt
+            if len(frame) < 60:  # pad to Ethernet minimum frame size
+                frame += b"\x00" * (60 - len(frame))
+            raw.send(frame)
+
+        actual = DROP
+        deadline = time.time() + args.timeout
+        while time.time() < deadline:
+            try:
+                data, _ = rx.recvfrom(2048)
+            except socket.timeout:
+                break
+            if len(data) < 20:
+                continue
+            magic, rid, verdict, rlen, ccrc = struct.unpack("<IIIII", data[:20])
+            if magic != REPLY_MAGIC or rid != test_id:
+                continue
+            actual = VERDICT_NAMES.get(verdict, f"verdict_{verdict}")
+            actual_detail = f"{actual} (rx_len={rlen})"
+            break
+        else:
+            actual_detail = DROP
+        if actual == DROP:
+            actual_detail = DROP
+
+        ok = actual == expected
+        passed += ok
+        failed += not ok
+        flag = "PASS" if ok else "FAIL"
+        print(f"[{flag}] {name:28s} expected={expected:14s} actual={actual_detail}")
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/net_corruption_test/send_corrupt.py
+++ b/tools/net_corruption_test/send_corrupt.py
@@ -286,8 +286,10 @@ def find_iface_for_ip(src_ip):
     raise RuntimeError(f"no interface found for source IP {src_ip}")
 
 
-def resolve_dst_mac(dst_ip):
+def resolve_dst_mac(dst_ip, iface):
     # Prime the ARP cache with a throwaway datagram, then read /proc/net/arp.
+    # Scope the lookup to `iface`: on a multi-homed host the same IP could have
+    # a stale/foreign entry on another device, which would yield the wrong MAC.
     p = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         p.sendto(b"\x00", (dst_ip, 9))  # discard port
@@ -295,14 +297,16 @@ def resolve_dst_mac(dst_ip):
         pass
     finally:
         p.close()
+    # /proc/net/arp columns: IP address, HW type, Flags, HW address, Mask, Device
     for _ in range(20):
         with open("/proc/net/arp") as f:
             for line in f.read().splitlines()[1:]:
                 cols = line.split()
-                if cols and cols[0] == dst_ip and cols[3] != "00:00:00:00:00:00":
+                if len(cols) >= 6 and cols[0] == dst_ip and cols[5] == iface \
+                        and cols[3] != "00:00:00:00:00:00":
                     return bytes(int(x, 16) for x in cols[3].split(":"))
         time.sleep(0.1)
-    raise RuntimeError(f"could not resolve MAC for {dst_ip} (is it reachable?)")
+    raise RuntimeError(f"could not resolve MAC for {dst_ip} on {iface} (is it reachable?)")
 
 
 def mac_str(mac):
@@ -320,13 +324,18 @@ def main():
     ap.add_argument("--only", help="run only the named test case")
     args = ap.parse_args()
 
+    if args.only:
+        known = [name for name, _, _ in TEST_CASES]
+        if args.only not in known:
+            sys.exit(f"unknown test case '{args.only}'; known cases: {', '.join(known)}")
+
     src_ip = args.src_ip or detect_src_ip(args.dst_ip)
     iface = args.iface or find_iface_for_ip(src_ip)
     src_mac = get_if_hwaddr(iface)
     if args.dst_mac:
         dst_mac = bytes(int(x, 16) for x in args.dst_mac.split(":"))
     else:
-        dst_mac = resolve_dst_mac(args.dst_ip)
+        dst_mac = resolve_dst_mac(args.dst_ip, iface)
     eth_hdr = dst_mac + src_mac + struct.pack("!H", ETH_P_IP)
 
     print(f"iface {iface}  src {src_ip}:{args.src_port} ({mac_str(src_mac)})")


### PR DESCRIPTION
… calculation into hardware to get some CPU cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a firmware UDP checksum/corruption test interface with automatic startup initialization.
  * Added a host-side tool to craft Ethernet/IP/UDP packets with controlled corruption and report verdicts.
* **Bug Fixes**
  * Improved handling of invalid received network frames to prevent RX stalls.
  * Updated IPv4/L4 checksum offload and fragmentation/reassembly settings to align with hardware behavior.
* **Documentation**
  * Added detailed test documentation, including packet/CRC rules and expected results.
* **Chores**
  * Included the checksum test interface in the firmware build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->