### PR TITLE
Recover I2C peripheral from bus-storm hangs

### DIFF
--- a/boards/XCORE/board_ex.c
+++ b/boards/XCORE/board_ex.c
@@ -21,6 +21,7 @@ void initBoardPeriphs(void) {
   // i2c1Config.timingr = 0x60404E72;
   // 20kHz:
   i2c1Config.timingr = 0xE020D5F2;
+  i2c1Config.cr1 = 0b111100000000;
 
   if (i2cStart(&I2CD1, &i2c1Config) != HAL_RET_SUCCESS) {
     while (1)
@@ -34,6 +35,7 @@ void initBoardPeriphs(void) {
 
   // Calculated depending on clock source, check reference manual
   i2c2Config.timingr = 0x60404E72;
+  i2c2Config.cr1 = 0b111100000000;
 
   if (i2cStart(&I2CD2, &i2c2Config) != HAL_RET_SUCCESS) {
     while (1)
@@ -47,6 +49,7 @@ void initBoardPeriphs(void) {
 
   // Calculated depending on clock source, check reference manual
   i2c4Config.timingr = 0xE14;
+  i2c4Config.cr1 = 0b111100000000;
 
   if (i2cStart(&I2CD4, &i2c4Config) != HAL_RET_SUCCESS) {
     while (1)

--- a/ext/ChibiOS_21.11.3/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
+++ b/ext/ChibiOS_21.11.3/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
@@ -337,6 +337,19 @@ static void i2c_lld_serve_interrupt(I2CDriver *i2cp, uint32_t isr) {
     return;
   }
 
+  /* Self-heal: direction desync. A per-byte flag is asserted that the current
+     software state cannot service -> the flag is not ICR-clearable and would
+     re-fire forever (IRQ storm -> tick starvation -> IWDG reset). Abort cleanly
+     so the high-level timeout can recover the bus. Root-cause-agnostic. */
+  if ((((isr & I2C_ISR_TXIS) != 0U) && (i2cp->state != I2C_ACTIVE_TX)) ||
+      (((isr & I2C_ISR_RXNE) != 0U) && (i2cp->state == I2C_ACTIVE_TX))) {
+    dp->CR2 |= I2C_CR2_STOP;
+    dp->CR1 &= ~(I2C_CR1_TCIE | I2C_CR1_TXIE | I2C_CR1_RXIE);
+    i2cp->errors |= I2C_BUS_ERROR;
+    _i2c_wakeup_error_isr(i2cp);
+    return;
+  }
+
 #if STM32_I2C_USE_DMA == FALSE
   /* Handling of data transfer if the DMA mode is disabled.*/
   {
@@ -1077,6 +1090,7 @@ void i2c_lld_stop(I2CDriver *i2cp) {
 msg_t i2c_lld_master_receive_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                      uint8_t *rxbuf, size_t rxbytes,
                                      sysinterval_t timeout) {
+  chDbgAssert(i2cp->mutex.owner == chThdGetSelfX(), "MUTEX FAILED");
   msg_t msg;
   I2C_TypeDef *dp = i2cp->i2c;
   systime_t start, end;
@@ -1203,6 +1217,7 @@ msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
                                       const uint8_t *txbuf, size_t txbytes,
                                       uint8_t *rxbuf, size_t rxbytes,
                                       sysinterval_t timeout) {
+  chDbgAssert(i2cp->mutex.owner == chThdGetSelfX(), "MUTEX FAILED");
   msg_t msg;
   I2C_TypeDef *dp = i2cp->i2c;
   systime_t start, end;

--- a/ext/ChibiOS_21.11.3/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
+++ b/ext/ChibiOS_21.11.3/os/hal/ports/STM32/LLD/I2Cv3/hal_i2c_lld.c
@@ -342,7 +342,7 @@ static void i2c_lld_serve_interrupt(I2CDriver *i2cp, uint32_t isr) {
      re-fire forever (IRQ storm -> tick starvation -> IWDG reset). Abort cleanly
      so the high-level timeout can recover the bus. Root-cause-agnostic. */
   if ((((isr & I2C_ISR_TXIS) != 0U) && (i2cp->state != I2C_ACTIVE_TX)) ||
-      (((isr & I2C_ISR_RXNE) != 0U) && (i2cp->state == I2C_ACTIVE_TX))) {
+      (((isr & I2C_ISR_RXNE) != 0U) && (i2cp->state != I2C_ACTIVE_RX))) {
     dp->CR2 |= I2C_CR2_STOP;
     dp->CR1 &= ~(I2C_CR1_TCIE | I2C_CR1_TXIE | I2C_CR1_RXIE);
     i2cp->errors |= I2C_BUS_ERROR;

--- a/src/drivers/bms/sabo_bms_driver.cpp
+++ b/src/drivers/bms/sabo_bms_driver.cpp
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "i2c_utils.hpp"
 #include "json_utils.hpp"
 #include "sbs_debug.hpp"
 
@@ -393,12 +394,19 @@ bool SaboBmsDriver::DumpDevice() {
   return true;
 }
 
+msg_t SaboBmsDriver::I2cMasterTransmit(const uint8_t* tx, size_t tx_len, uint8_t* rx, size_t rx_len) {
+  chDbgAssert(bms_cfg_->i2c && bms_cfg_->i2c->mutex.owner == chThdGetSelfX(), "NEED TO OWN THE I2C");
+  return xbot::i2c::TransmitWithRecovery(bms_cfg_->i2c, DEVICE_ADDRESS, tx, tx_len, rx, rx_len, "BMS",
+                                         i2c_retry_delay_ms);
+}
+
 msg_t SaboBmsDriver::ReadRegisterRaw(uint8_t reg, uint8_t* rx, size_t rx_len) {
+  chDbgAssert(bms_cfg_->i2c && bms_cfg_->i2c->mutex.owner == chThdGetSelfX(), "NEED TO OWN THE I2C");
   if (bms_cfg_ == nullptr || bms_cfg_->i2c == nullptr || rx == nullptr || rx_len == 0) return MSG_RESET;
 
   msg_t last_msg = MSG_RESET;
   for (unsigned attempt = 0; attempt < i2c_retries; attempt++) {
-    const msg_t msg = i2cMasterTransmit(bms_cfg_->i2c, DEVICE_ADDRESS, &reg, 1, rx, rx_len);
+    const msg_t msg = I2cMasterTransmit(&reg, 1, rx, rx_len);
     last_msg = msg;
     if (msg == MSG_OK) break;
     chThdSleepMilliseconds(i2c_retry_delay_ms);
@@ -408,6 +416,7 @@ msg_t SaboBmsDriver::ReadRegisterRaw(uint8_t reg, uint8_t* rx, size_t rx_len) {
 }
 
 msg_t SaboBmsDriver::ReadRegister(uint8_t reg, uint8_t& result) {
+  chDbgAssert(bms_cfg_->i2c && bms_cfg_->i2c->mutex.owner == chThdGetSelfX(), "NEED TO OWN THE I2C");
   uint8_t rx = 0;
   const msg_t msg = ReadRegisterRaw(reg, &rx, 1);
   if (msg == MSG_OK) result = rx;
@@ -415,6 +424,7 @@ msg_t SaboBmsDriver::ReadRegister(uint8_t reg, uint8_t& result) {
 }
 
 msg_t SaboBmsDriver::ReadRegister(uint8_t reg, uint16_t& result) {
+  chDbgAssert(bms_cfg_->i2c && bms_cfg_->i2c->mutex.owner == chThdGetSelfX(), "NEED TO OWN THE I2C");
   uint8_t rx[2] = {0, 0};
   const msg_t msg = ReadRegisterRaw(reg, rx, 2);
   if (msg == MSG_OK) result = (uint16_t)rx[0] | (uint16_t)((uint16_t)rx[1] << 8);
@@ -422,6 +432,7 @@ msg_t SaboBmsDriver::ReadRegister(uint8_t reg, uint16_t& result) {
 }
 
 msg_t SaboBmsDriver::ReadRegister(uint8_t reg, int16_t& result) {
+  chDbgAssert(bms_cfg_->i2c && bms_cfg_->i2c->mutex.owner == chThdGetSelfX(), "NEED TO OWN THE I2C");
   uint16_t u = 0;
   const msg_t msg = ReadRegister(reg, u);
   if (msg == MSG_OK) result = (int16_t)u;
@@ -429,6 +440,7 @@ msg_t SaboBmsDriver::ReadRegister(uint8_t reg, int16_t& result) {
 }
 
 msg_t SaboBmsDriver::ReadBlock(uint8_t cmd, uint8_t* data, size_t data_capacity, size_t& out_len) {
+  chDbgAssert(bms_cfg_->i2c && bms_cfg_->i2c->mutex.owner == chThdGetSelfX(), "NEED TO OWN THE I2C");
   out_len = 0;
   if (!bms_cfg_ || !bms_cfg_->i2c || !data || !data_capacity) return MSG_RESET;
 
@@ -440,7 +452,7 @@ msg_t SaboBmsDriver::ReadBlock(uint8_t cmd, uint8_t* data, size_t data_capacity,
 
   for (unsigned attempt = 0; attempt < i2c_retries; attempt++) {
     memset(data, 0, rx_max);
-    const msg_t msg = i2cMasterTransmit(bms_cfg_->i2c, DEVICE_ADDRESS, &cmd, 1, data, rx_max);
+    const msg_t msg = I2cMasterTransmit(&cmd, 1, data, rx_max);
     last_msg = msg;
     if (msg != MSG_OK) {
       chThdSleepMilliseconds(i2c_retry_delay_ms);

--- a/src/drivers/bms/sabo_bms_driver.cpp
+++ b/src/drivers/bms/sabo_bms_driver.cpp
@@ -343,7 +343,10 @@ bool SaboBmsDriver::DumpDevice() {
   opt.list_unknown_nonzero = true;
   opt.suppress_cmds_0x3c_0x42 = true;  // printed separately as cell voltages
 
+  i2cAcquireBus(bms_cfg_->i2c);
+
   if (!debug::DumpSbsDevice(sbs_, cb, opt)) {
+    i2cReleaseBus(bms_cfg_->i2c);
     return false;
   }
 
@@ -390,6 +393,8 @@ bool SaboBmsDriver::DumpDevice() {
       BmsPrintLine(line);
     }
   }
+
+  i2cReleaseBus(bms_cfg_->i2c);
 
   return true;
 }

--- a/src/drivers/bms/sabo_bms_driver.hpp
+++ b/src/drivers/bms/sabo_bms_driver.hpp
@@ -73,6 +73,11 @@ class SaboBmsDriver : public BmsDriver {
   msg_t SbsReadInt16(uint8_t cmd, int16_t& out);
   msg_t SbsReadBlock(uint8_t cmd, uint8_t* data, size_t data_capacity, size_t& out_len);
 
+  // Wraps i2cMasterTransmit. On a bus timeout the peripheral is left in the
+  // I2C_LOCKED state and must be restarted before it can be reused; this
+  // restarts it and loops until the restart succeeds.
+  msg_t I2cMasterTransmit(const uint8_t* tx, size_t tx_len, uint8_t* rx, size_t rx_len);
+
   msg_t ReadRegisterRaw(uint8_t reg, uint8_t* rx, size_t rx_len);
   msg_t ReadRegister(uint8_t reg, uint8_t& result);
   msg_t ReadRegister(uint8_t reg, uint16_t& result);

--- a/src/drivers/charger/bq_2576/bq_2576.cpp
+++ b/src/drivers/charger/bq_2576/bq_2576.cpp
@@ -87,7 +87,7 @@ bool BQ2576::readRegister(uint8_t reg, uint8_t& result) {
     return false;
   }
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, &reg, sizeof(reg), &result, sizeof(result)) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, &reg, sizeof(reg), &result, sizeof(result)) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }
@@ -125,8 +125,8 @@ bool BQ2576::readRegister(uint8_t reg, uint16_t& result) {
   }
 
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, &reg, sizeof(reg), reinterpret_cast<uint8_t*>(&result),
-                              sizeof(result)) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, &reg, sizeof(reg), reinterpret_cast<uint8_t*>(&result),
+                               sizeof(result)) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }
@@ -138,7 +138,7 @@ bool BQ2576::writeRegister8(uint8_t reg, uint8_t value) {
 
   uint8_t payload[2] = {reg, value};
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }
@@ -151,7 +151,7 @@ bool BQ2576::writeRegister16(uint8_t reg, uint16_t value) {
   const auto ptr = reinterpret_cast<uint8_t*>(&value);
   uint8_t payload[3] = {reg, ptr[0], ptr[1]};
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }

--- a/src/drivers/charger/bq_2579/bq_2579.cpp
+++ b/src/drivers/charger/bq_2579/bq_2579.cpp
@@ -132,7 +132,7 @@ bool BQ2579::readRegister(uint8_t reg, uint8_t& result) {
     return false;
   }
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, &reg, sizeof(reg), &result, sizeof(result)) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, &reg, sizeof(reg), &result, sizeof(result)) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }
@@ -142,7 +142,7 @@ bool BQ2579::readRegister(uint8_t reg, uint16_t& result) {
   }
   i2cAcquireBus(i2c_driver_);
   uint8_t buf[2];
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, &reg, sizeof(reg), buf, sizeof(buf)) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, &reg, sizeof(reg), buf, sizeof(buf)) == MSG_OK;
   result = buf[0] << 8 | buf[1];
   i2cReleaseBus(i2c_driver_);
   return ok;
@@ -153,7 +153,7 @@ bool BQ2579::writeRegister8(uint8_t reg, uint8_t value) {
   }
   uint8_t payload[2] = {reg, value};
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }
@@ -165,7 +165,7 @@ bool BQ2579::writeRegister16(uint8_t reg, uint16_t value) {
   const auto ptr = reinterpret_cast<uint8_t*>(&value);
   uint8_t payload[3] = {reg, ptr[1], ptr[0]};
   i2cAcquireBus(i2c_driver_);
-  bool ok = i2cMasterTransmit(i2c_driver_, DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
+  bool ok = i2cTransmitChecked(DEVICE_ADDRESS, payload, sizeof(payload), nullptr, 0) == MSG_OK;
   i2cReleaseBus(i2c_driver_);
   return ok;
 }

--- a/src/drivers/charger/charger.hpp
+++ b/src/drivers/charger/charger.hpp
@@ -5,13 +5,22 @@
 #ifndef CHARGER_HPP
 #define CHARGER_HPP
 
+#include <ch.h>
 #include <hal.h>
 
 #include <limits>
 
+#include "i2c_utils.hpp"
+
 class ChargerDriver {
  protected:
   I2CDriver *i2c_driver_ = nullptr;
+
+  // Wraps i2cMasterTransmit with bus-storm recovery. The caller must already
+  // hold the I2C bus.
+  msg_t i2cTransmitChecked(uint8_t addr, const uint8_t *tx, size_t tx_len, uint8_t *rx, size_t rx_len) {
+    return xbot::i2c::TransmitWithRecovery(i2c_driver_, addr, tx, tx_len, rx, rx_len, "Charger");
+  }
 
  public:
   enum class CHARGER_STATUS : uint8_t {

--- a/src/i2c_utils.hpp
+++ b/src/i2c_utils.hpp
@@ -1,0 +1,56 @@
+//
+// Shared I2C helpers.
+//
+
+#ifndef XBOT_I2C_UTILS_HPP
+#define XBOT_I2C_UTILS_HPP
+
+#include <ch.h>
+#include <hal.h>
+#include <ulog.h>
+
+#include <cstddef>
+
+namespace xbot::i2c {
+
+// Wraps i2cMasterTransmit with bus-storm recovery. A bus timeout leaves the
+// peripheral in the I2C_LOCKED state and it must be restarted (i2cStop +
+// i2cStart) before it can be used again; this restarts it and loops until the
+// restart succeeds. The caller must already hold the I2C bus.
+//
+// `tag` prefixes the log lines so callers (e.g. "BMS", "Charger") stay
+// distinguishable on the console. `restart_retry_delay_ms` is the back-off
+// between failed restart attempts.
+inline msg_t TransmitWithRecovery(I2CDriver* i2c, uint8_t addr, const uint8_t* tx, size_t tx_len, uint8_t* rx,
+                                  size_t rx_len, const char* tag, uint32_t restart_retry_delay_ms = 2) {
+  const msg_t msg = i2cMasterTransmit(i2c, addr, tx, tx_len, rx, rx_len);
+  if (msg != MSG_OK) {
+    // Distinguish the two recovery causes. MSG_TIMEOUT = the high-level bus
+    // timeout (peripheral left in I2C_LOCKED). MSG_RESET + I2C_BUS_ERROR = the
+    // in-ISR self-heal tripped on a direction desync (the IRQ storm).
+    const i2cflags_t errs = i2cGetErrors(i2c);
+    if (msg == MSG_TIMEOUT) {
+      ULOG_WARNING("%s I2C TIMEOUT recovery (bus locked) - restarting I2C peripheral", tag);
+    } else if ((errs & I2C_BUS_ERROR) != 0) {
+      ULOG_WARNING("%s I2C ISR-STORM self-heal recovery (direction desync, errs=0x%02x) - restarting I2C peripheral",
+                   tag, (unsigned)errs);
+    } else {
+      ULOG_WARNING("%s I2C error recovery (msg=%d errs=0x%02x) - restarting I2C peripheral", tag, (int)msg,
+                   (unsigned)errs);
+    }
+    while (true) {
+      const auto old_cfg = i2c->config;
+      i2cStop(i2c);
+      if (i2cStart(i2c, old_cfg) == HAL_RET_SUCCESS) {
+        break;
+      }
+      ULOG_ERROR("%s I2C restart failed - retrying", tag);
+      chThdSleepMilliseconds(restart_retry_delay_ms);
+    }
+  }
+  return msg;
+}
+
+}  // namespace xbot::i2c
+
+#endif  // XBOT_I2C_UTILS_HPP

--- a/src/services/bms_service/bms_service.hpp
+++ b/src/services/bms_service/bms_service.hpp
@@ -35,7 +35,7 @@ class BmsService : public BmsServiceBase {
   BmsDriver* bms_ = nullptr;
   const Data* bms_data_ = nullptr;
   const char* bms_extra_data_ = nullptr;
-  THD_WORKING_AREA(wa, 768){};
+  THD_WORKING_AREA(wa, 2048){};
 };
 
 #endif  // BMS_SERVICE_HPP


### PR DESCRIPTION
## Problem

The STM32 I2Cv3 LLD could decouple its software state from the CR2 transfer direction. The mismatched per-byte flag (`TXIS`/`RXNE`) is **not** ICR-clearable, so the ISR re-fires forever → tick starvation → IWDG reset. Observed as a hard I2C-bus hang.

## Changes

**LLD (`hal_i2c_lld.c`)**
- Self-heal: detect the direction desync in the ISR and abort cleanly (`STOP` + disable TC/TX/RX IRQs + flag `I2C_BUS_ERROR`) so the high-level timeout can recover the bus. Root-cause-agnostic.
- `chDbgAssert` mutex-ownership checks on the master transfer paths.

**Shared helper (`src/i2c_utils.hpp`)**
- `xbot::i2c::TransmitWithRecovery` wraps `i2cMasterTransmit`: on timeout/desync the peripheral is restarted (`i2cStop` + `i2cStart`, retried until success), with distinct logging for the timeout vs ISR-storm recovery classes. The BMS (`sabo_bms_driver`) and chargers (`bq_2576`, `bq_2579`) now call this instead of each carrying its own copy.

**Board**
- XCORE: set I2C `CR1` to enable the relevant error interrupts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved I2C communication reliability across battery, charger, and BMS features.
  * Added better recovery when an I2C transfer times out or the bus gets out of sync.
  * Fixed several register read/write paths to use safer checked transfers.
  * Increased an internal service thread buffer to help prevent runtime stack issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->