### PR TITLE
feat: Unified firmware binary with runtime robot detection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,24 +46,8 @@ jobs:
       - name: Copy Artifacts
         run: |
           mkdir artifacts
-          cp ./out/openmower-yardforce.bin ./artifacts
-          cp ./out/openmower-yardforce.elf ./artifacts
-          cp ./out/openmower-yardforce-v4.bin ./artifacts
-          cp ./out/openmower-yardforce-v4.elf ./artifacts
-          cp ./out/openmower-worx.bin ./artifacts
-          cp ./out/openmower-worx.elf ./artifacts
-          cp ./out/openmower-lyfco-e1600.bin ./artifacts
-          cp ./out/openmower-lyfco-e1600.elf ./artifacts
-          cp ./out/openmower-sabo.bin ./artifacts
-          cp ./out/openmower-sabo.elf ./artifacts
-          cp ./out/openmower-universal-5s.bin ./artifacts
-          cp ./out/openmower-universal-5s.elf ./artifacts
-          cp ./out/openmower-universal-7s.bin ./artifacts
-          cp ./out/openmower-universal-7s.elf ./artifacts
-          cp ./out/openmower-universal-8s.bin ./artifacts
-          cp ./out/openmower-universal-8s.elf ./artifacts
-          cp ./out/openmower-husq310MKII.bin ./artifacts
-          cp ./out/openmower-husq310MKII.elf ./artifacts
+          cp ./out/openmower.bin ./artifacts
+          cp ./out/openmower.elf ./artifacts
           cp ./out/ram-info.html ./artifacts
           cp ./out/flash-info.html ./artifacts
       - name: Upload Artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,8 +46,8 @@ jobs:
       - name: Copy Artifacts
         run: |
           mkdir artifacts
-          cp ./out/openmower.bin ./artifacts
-          cp ./out/openmower.elf ./artifacts
+          cp ./out/openmower-firmware.bin ./artifacts
+          cp ./out/openmower-firmware.elf ./artifacts
           cp ./out/ram-info.html ./artifacts
           cp ./out/flash-info.html ./artifacts
       - name: Upload Artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: openmower
+          name: openmower-firmware
           path: artifacts/
   tagged-release:
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
       - name: Download artifacts from build stage
         uses: actions/download-artifact@v4
         with:
-          name: openmower
+          name: openmower-firmware
           path: artifacts
       - name: Compress release directory into a versioned ZIP file
         run: cd artifacts && zip -r "../fw-openmower-v2-${{ github.ref_name }}.zip" .

--- a/.idea/runConfigurations/Openmower.xml
+++ b/.idea/runConfigurations/Openmower.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Openmower" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-device &quot;STM32H723ZG&quot; -if swd -speed 8000 -port 31787 -nogui -singlerun" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="openmower" TARGET_NAME="openmower" CONFIG_NAME="Debug - Debug" version="1" RUN_TARGET_PROJECT_NAME="openmower" RUN_TARGET_NAME="openmower">
+    <custom-gdb-server version="1" gdb-connect="tcp::31787" executable="/usr/bin/JLinkGDBServerCLExe" warmup-ms="0" download-type="ALWAYS" reset-cmd="monitor reset" reset-type="AFTER_DOWNLOAD">
+      <debugger kind="GDB" isBundled="true" />
+    </custom-gdb-server>
+    <method v="2">
+      <option name="CLION.COMPOUND.BUILD" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,22 +4,6 @@
 // Once done, start OpenOCD on your CM4 host via:
 //   openocd -f interface/xcore.cfg -f target/stm32h7x.cfg -c "bindto 0.0.0.0"
 // Also make sure you have the Dev Mode enabled in the bootloader.
-//
-// Since ROBOT_PLATFORM you also like to create a <project-root>/CMakeUserPresets.json file with a content like:
-//{
-//    "version": 3,
-//    "configurePresets": [
-//        {
-//            "name": "RobotDebug",
-//            "inherits": "Debug",
-//            "cacheVariables": {
-//                "ROBOT_PLATFORM": "YardForce",
-//                "CMAKE_BUILD_TYPE": "Debug"
-//            }
-//        }
-//    ]
-//}
-// and select it in your CMake extension settings.
 {
     "version": "0.2.0",
     "configurations": [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(XBOT_CUSTOM_PORT_PATH ${CMAKE_SOURCE_DIR}/portable/xbot)
 set(XBOT_SERVICE_EXT "services/service_ext.hpp")
 
 # Set the project name
-set(CMAKE_PROJECT_NAME openmower)
+set(CMAKE_PROJECT_NAME openmower-firmware)
 
 # Include toolchain file
 include("cmake/gcc-arm-none-eabi.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
         src/services/gps_service/gps_service.cpp
         src/services/input_service/input_service.cpp
         src/services/high_level_service/high_level_service.cpp
+        src/services/meta_service/meta_service.cpp
         # BQ2567 driver
         src/drivers/charger/bq_2576/bq_2576.cpp
         # BQ25679 driver
@@ -147,7 +148,6 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
         # Add user defined symbols
         timegm=mktime
-        ROBOT_PLATFORM=${ROBOT_PLATFORM}
 )
 
 # Add linked libraries
@@ -170,6 +170,7 @@ target_add_service(${CMAKE_PROJECT_NAME} MowerService ${CMAKE_CURRENT_SOURCE_DIR
 target_add_service(${CMAKE_PROJECT_NAME} GpsService ${CMAKE_CURRENT_SOURCE_DIR}/services/gps_service.json)
 target_add_service(${CMAKE_PROJECT_NAME} InputService ${CMAKE_CURRENT_SOURCE_DIR}/services/input_service.json)
 target_add_service(${CMAKE_PROJECT_NAME} HighLevelService ${CMAKE_CURRENT_SOURCE_DIR}/services/high_level_service.json)
+target_add_service(${CMAKE_PROJECT_NAME} MetaService ${CMAKE_CURRENT_SOURCE_DIR}/services/meta_service.json)
 
 set_target_properties(${CMAKE_PROJECT_NAME}
         PROPERTIES SUFFIX ".elf")

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,12 @@ RUN mkdir build
 # Share one FetchContent download/source dir so deps are fetched once.
 ENV FETCHCONTENT_BASE_DIR=/project/build/_deps
 RUN cd build && cmake .. --preset=${BUILD_PRESET} -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -B${BUILD_PRESET} && cd ${BUILD_PRESET} && make -j$(nproc)
-RUN elf-size-analyze -H -R -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower.elf -W > build/ram-info.html
-RUN elf-size-analyze -H -F -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower.elf -W > build/flash-info.html
+RUN elf-size-analyze -H -R -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower-firmware.elf -W > build/ram-info.html
+RUN elf-size-analyze -H -F -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower-firmware.elf -W > build/flash-info.html
 
 FROM scratch
 ARG BUILD_PRESET=Release
 COPY --from=builder /project/build/ram-info.html /ram-info.html
 COPY --from=builder /project/build/flash-info.html /flash-info.html
-COPY --from=builder /project/build/${BUILD_PRESET}/openmower.bin /openmower.bin
-COPY --from=builder /project/build/${BUILD_PRESET}/openmower.elf /openmower.elf
+COPY --from=builder /project/build/${BUILD_PRESET}/openmower-firmware.bin /openmower-firmware.bin
+COPY --from=builder /project/build/${BUILD_PRESET}/openmower-firmware.elf /openmower-firmware.elf

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN elf-size-analyze -H -R -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower.e
 RUN elf-size-analyze -H -F -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower.elf -W > build/flash-info.html
 
 FROM scratch
+ARG BUILD_PRESET=Release
 COPY --from=builder /project/build/ram-info.html /ram-info.html
 COPY --from=builder /project/build/flash-info.html /flash-info.html
 COPY --from=builder /project/build/${BUILD_PRESET}/openmower.bin /openmower.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,19 +9,6 @@ RUN apt-get update && apt-get install -y  \
     make \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ccache (TODO: REMOVE as soon as we have universal firmware)
-RUN apt-get update && apt-get install -y ccache \
-    && rm -rf /var/lib/apt/lists/* \
-    && /usr/sbin/update-ccache-symlinks
-ENV PATH="/usr/lib/ccache:$PATH"
-# Each platform builds in its own dir (build/<platform>) with a different CWD.
-# Without these, ccache hashes the absolute paths in the compiler args and the
-# working directory, so identical dependency sources (ChibiOS, lvgl, ...) miss
-# the cache on every platform. BASEDIR rewrites abs paths under /project to
-# relative; NOHASHDIR drops the CWD from the hash.
-ENV CCACHE_BASEDIR="/project"
-ENV CCACHE_NOHASHDIR="true"
-
 RUN pip install elf-size-analyze
 
 # Build preset to use for all platforms. CI passes "Debug" for pull requests and
@@ -33,57 +20,14 @@ COPY . /project
 WORKDIR /project
 RUN mkdir build
 
-# Share one FetchContent download/source dir across all platform configures so
-# deps like lwjson are fetched from GitHub once instead of once per platform
-# (avoids tripping codeload's transient 500s / rate limiting).
+# Share one FetchContent download/source dir so deps are fetched once.
 ENV FETCHCONTENT_BASE_DIR=/project/build/_deps
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=YardForce -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BYardForce && cd YardForce && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=YardForce_V4 -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BYardForce_V4 && cd YardForce_V4 && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Worx -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BWorx && cd Worx && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Lyfco_E1600 -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BLyfco_E1600 && cd Lyfco_E1600 && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Sabo -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BSabo && cd Sabo && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=xBot -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BxBot && cd xBot && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Universal5S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal5S && cd Universal5S && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Universal7S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal7S && cd Universal7S && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=Universal8S -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -BUniversal8S && cd Universal8S && make -j$(nproc)
-RUN cd build && cmake .. --preset=${BUILD_PRESET} -DROBOT_PLATFORM=husq310MKII -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -Bhusq310MKII && cd husq310MKII && make -j$(nproc)
-
-# Use Sabo build for RAM and ROM analysis for now - it has the most libraries
-RUN elf-size-analyze -H -R -t arm-none-eabi- ./build/Sabo/openmower.elf -W > build/ram-info.html
-RUN elf-size-analyze -H -F -t arm-none-eabi- ./build/Sabo/openmower.elf -W > build/flash-info.html
-RUN ccache -s > build/ccache.txt
+RUN cd build && cmake .. --preset=${BUILD_PRESET} -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR} -B${BUILD_PRESET} && cd ${BUILD_PRESET} && make -j$(nproc)
+RUN elf-size-analyze -H -R -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower.elf -W > build/ram-info.html
+RUN elf-size-analyze -H -F -t arm-none-eabi- ./build/${BUILD_PRESET}/openmower.elf -W > build/flash-info.html
 
 FROM scratch
-COPY --from=builder /project/build/ccache.txt /ccache.txt
 COPY --from=builder /project/build/ram-info.html /ram-info.html
 COPY --from=builder /project/build/flash-info.html /flash-info.html
-
-COPY --from=builder /project/build/YardForce/openmower.bin /openmower-yardforce.bin
-COPY --from=builder /project/build/YardForce/openmower.elf /openmower-yardforce.elf
-
-COPY --from=builder /project/build/YardForce_V4/openmower.bin /openmower-yardforce-v4.bin
-COPY --from=builder /project/build/YardForce_V4/openmower.elf /openmower-yardforce-v4.elf
-
-COPY --from=builder /project/build/Worx/openmower.bin /openmower-worx.bin
-COPY --from=builder /project/build/Worx/openmower.elf /openmower-worx.elf
-
-COPY --from=builder /project/build/Lyfco_E1600/openmower.bin /openmower-lyfco-e1600.bin
-COPY --from=builder /project/build/Lyfco_E1600/openmower.elf /openmower-lyfco-e1600.elf
-
-COPY --from=builder /project/build/Sabo/openmower.bin /openmower-sabo.bin
-COPY --from=builder /project/build/Sabo/openmower.elf /openmower-sabo.elf
-
-COPY --from=builder /project/build/xBot/openmower.bin /openmower-xbot.bin
-COPY --from=builder /project/build/xBot/openmower.elf /openmower-xbot.elf
-
-COPY --from=builder /project/build/Universal5S/openmower.bin /openmower-universal-5s.bin
-COPY --from=builder /project/build/Universal5S/openmower.elf /openmower-universal-5s.elf
-
-COPY --from=builder /project/build/Universal7S/openmower.bin /openmower-universal-7s.bin
-COPY --from=builder /project/build/Universal7S/openmower.elf /openmower-universal-7s.elf
-
-COPY --from=builder /project/build/Universal8S/openmower.bin /openmower-universal-8s.bin
-COPY --from=builder /project/build/Universal8S/openmower.elf /openmower-universal-8s.elf
-
-COPY --from=builder /project/build/husq310MKII/openmower.bin /openmower-husq310MKII.bin
-COPY --from=builder /project/build/husq310MKII/openmower.elf /openmower-husq310MKII.elf
+COPY --from=builder /project/build/${BUILD_PRESET}/openmower.bin /openmower.bin
+COPY --from=builder /project/build/${BUILD_PRESET}/openmower.elf /openmower.elf

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Real-time embedded firmware for the xCore board -- the low-level controller in t
 
 This repository contains the firmware that runs on the **xCore board** (STM32H723 Cortex-M7) using [ChibiOS](https://www.chibios.org/) as its real-time operating system. The firmware is responsible for all low-level hardware control: driving motors via [xESC](https://github.com/ClemensElflein/xESC) controllers, reading GPS and IMU sensors, managing battery charging, enforcing safety systems, and processing user inputs. It communicates with a **Raspberry Pi Compute Module 4** over Ethernet, where the [open_mower_ros](https://github.com/ClemensElflein/open_mower_ros) ROS stack handles navigation, path planning, and high-level mission control.
 
-A single codebase supports **6 different robot platforms** through compile-time platform selection, each with its own carrier board, battery configuration, and hardware-specific drivers.
+A single codebase supports **10 different robot platforms** through runtime robot detection. A single unified firmware binary automatically identifies the robot variant via EEPROM (Stage 1) or ROS configuration (Stage 2).
 
 ## System Architecture
 
@@ -22,16 +22,16 @@ A single codebase supports **6 different robot platforms** through compile-time 
 
 ## Supported Platforms
 
-The firmware supports 6 robot platforms, selected at compile time via `-DROBOT_PLATFORM=<value>`. Each platform defines its own battery parameters, motor drivers, charger IC, and carrier board compatibility.
+The firmware supports 10 robot platforms, selected at runtime via two-stage detection: Stage 1 (Sabo/xBot auto-detect from EEPROM) and Stage 2 (ROS sets the robot variant via the MetaService `Robot Firmware` register). Each platform defines its own battery parameters, motor drivers, charger IC, and carrier board compatibility. No compile-time flags are needed — a single binary serves all platforms.
 
-| Platform | CMake Value | Base Robot | Battery | Carrier Board | Charger | Notes |
-|---|---|---|---|---|---|---|
-| YardForce | `YardForce` | Classic 500(B) | 7S (29.4V) | hw-openmower-yardforce | BQ2576 | |
-| YardForce V4 | `YardForce_V4` | Classic 500(B) | 7S (29.4V) | hw-openmower-yardforce | BQ2576 | YFR4 mower ESC |
-| Worx | `Worx` | Worx models | 5S (21V) | hw-openmower-universal | BQ2576 | Worx input protocol |
-| Lyfco E1600 | `Lyfco_E1600` | Lyfco E1600 | 7S (29.4V) | hw-openmower-universal | BQ2576 | |
-| Sabo | `Sabo` | MOWit 500F / JD Tango E5 | 7S3P (29V) | hw-openmower-sabo | BQ2576 | BMS, CoverUI with LCD, dynamic power mgmt |
-| xBot | `xBot` | Reference / dev platform | 4S (16.8V) | hw-xbot-mainboard | BQ2579 | PWM motors, no mower service |
+| Platform     | Runtime Name   | Base Robot               | Battery      | Carrier Board          | Charger | Notes                                     |
+| ------------ | -------------- | ------------------------ | ------------ | ---------------------- | ------- | ----------------------------------------- |
+| YardForce    | `YardForce`    | Classic 500(B)           | 7S (29.4V)   | hw-openmower-yardforce | BQ2576  |                                           |
+| YardForce V4 | `YardForce-V4` | Classic 500(B)           | 7S (29.4V)   | hw-openmower-yardforce | BQ2576  | YFR4 mower ESC                            |
+| Worx         | `Worx`         | Worx models              | 5S (21V)     | hw-openmower-universal | BQ2576  | Worx input protocol                       |
+| Lyfco E1600  | `Lyfco_E1600`  | Lyfco E1600              | 7S (29.4V)   | hw-openmower-universal | BQ2576  |                                           |
+| Sabo         | `Sabo`         | MOWit 500F / JD Tango E5 | 7S3P (29.4V) | hw-openmower-sabo      | BQ2576  | BMS, CoverUI with LCD, dynamic power mgmt |
+| xBot         | `xBot`         | Reference / dev platform | 4S (16.8V)   | hw-xbot-mainboard      | BQ2579  | PWM motors, no mower service              |
 
 ## Prerequisites
 
@@ -58,40 +58,38 @@ If already cloned without `--recursive`:
 git submodule update --init --recursive
 ```
 
-### Quick Build (Single Platform)
+### Quick Build
 
 ```bash
-./build-binary.sh Release YardForce
+./build-binary.sh Release
 ```
 
-Output: `out/openmower-YardForce.elf` and `out/openmower-YardForce.bin`
+Output: `out/openmower-firmware.elf` and `out/openmower-firmware.bin`
 
 ### Manual CMake Build
 
 ```bash
-cmake . --preset=Release -DROBOT_PLATFORM=YardForce
+cmake . --preset=Release
 cd build/Release
 make -j$(nproc)
 ```
 
-Output: `build/Release/openmower.elf`, `openmower.bin`, `openmower.hex`
-
-> **Note:** `-DROBOT_PLATFORM` is required and has no default value. The build will fail without it.
+Output: `build/Release/openmower-firmware.elf`, `openmower-firmware.bin`, `openmower-firmware.hex`
 
 ### Build Presets
 
-| Preset | Build Type | Description |
-|---|---|---|
-| `Debug` | -O0 | Full debug symbols, `DEBUG_BUILD` defined (enables simulated input driver) |
-| `DebugRTT` | -O0 | Debug + SEGGER RTT real-time terminal |
-| `DebugSystemView` | -O0 | Debug + SEGGER RTT + SystemView tracing |
-| `Release` | -Os | Optimized, `RELEASE_BUILD` defined (bootloader reset config) |
-| `RelWithDebInfo` | -O2 -g | Release optimizations with debug symbols |
-| `MinSizeRel` | -Os | Minimum binary size |
+| Preset            | Build Type | Description                                                                |
+| ----------------- | ---------- | -------------------------------------------------------------------------- |
+| `Debug`           | -O0        | Full debug symbols, `DEBUG_BUILD` defined (enables simulated input driver) |
+| `DebugRTT`        | -O0        | Debug + SEGGER RTT real-time terminal                                      |
+| `DebugSystemView` | -O0        | Debug + SEGGER RTT + SystemView tracing                                    |
+| `Release`         | -Os        | Optimized, `RELEASE_BUILD` defined (bootloader reset config)               |
+| `RelWithDebInfo`  | -O2 -g     | Release optimizations with debug symbols                                   |
+| `MinSizeRel`      | -Os        | Minimum binary size                                                        |
 
 ### Docker Build (All Platforms)
 
-Builds all 6 platform binaries in one step and extracts them directly to `./out/`:
+Builds the unified firmware binary and extracts it directly to `./out/`:
 
 ```bash
 docker build -o ./out .
@@ -119,22 +117,7 @@ The easiest way to get started. Open the project in VS Code with the [Dev Contai
 
 ### Personal Build Preset
 
-Create a `CMakeUserPresets.json` (gitignored) to set your default platform:
-
-```json
-{
-    "version": 3,
-    "configurePresets": [
-        {
-            "name": "MyDebug",
-            "inherits": "Debug",
-            "cacheVariables": {
-                "ROBOT_PLATFORM": "YardForce"
-            }
-        }
-    ]
-}
-```
+For a custom build preset, create a `CMakeUserPresets.json` (gitignored). No platform flag is needed — the unified firmware binary detects the robot at runtime.
 
 ### Debugging
 
@@ -169,33 +152,33 @@ pre-commit install
 
 ### Service-Oriented Design
 
-The firmware is built around 8 services that communicate via the [xbot_framework](https://github.com/ClemensElflein/xbot_framework) message-passing system. Each service runs in its own ChibiOS thread. The framework also handles communication with the Raspberry Pi CM4 over Ethernet.
+The firmware is built around 9 services that communicate via the [xbot_framework](https://github.com/ClemensElflein/xbot_framework) message-passing system. Each service runs in its own ChibiOS thread. The framework also handles communication with the Raspberry Pi CM4 over Ethernet.
 
 Service definitions are maintained in a separate repository ([definitions-open-mower](https://github.com/xtech/definitions-open-mower)) and included as the `services/` submodule. These JSON definitions auto-generate C++ base classes with typed message accessors.
 
-| Service | Description |
-|---|---|
+| Service              | Description                                                                  |
+| -------------------- | ---------------------------------------------------------------------------- |
 | **EmergencyService** | Safety state machine with timeout-based shutdown and multi-source monitoring |
-| **DiffDriveService** | Differential drive motor control (left/right wheels) via VESC or PWM |
-| **MowerService** | Blade motor control (disabled on xBot platform) |
-| **PowerService** | Battery voltage monitoring, charger control (BQ2576/BQ2579), BMS integration |
-| **GpsService** | UBX and NMEA GPS protocol support with RTCM/RTK correction data |
-| **InputService** | User input aggregation with debouncing (GPIO, Sabo buttons, Worx protocol) |
-| **ImuService** | LSM6DS3TR-C 6-axis IMU with platform-specific axis remapping |
-| **HighLevelService** | Mission state coordination and progress tracking |
+| **DiffDriveService** | Differential drive motor control (left/right wheels) via VESC or PWM         |
+| **MowerService**     | Blade motor control (disabled on xBot platform)                              |
+| **PowerService**     | Battery voltage monitoring, charger control (BQ2576/BQ2579), BMS integration |
+| **GpsService**       | UBX and NMEA GPS protocol support with RTCM/RTK correction data              |
+| **InputService**     | User input aggregation with debouncing (GPIO, Sabo buttons, Worx protocol)   |
+| **ImuService**       | LSM6DS3TR-C 6-axis IMU with platform-specific axis remapping                 |
+| **HighLevelService** | Mission state coordination and progress tracking                             |
 
 ### Platform Abstraction
 
 The `Robot` base class (`robots/include/robot.hpp`) defines the hardware interface that each platform must implement: battery voltage thresholds, charger initialization, GPS port selection, and hardware compatibility checks. `MowerRobot` extends this with motor driver setup for standard mower platforms.
 
-Each platform has a concrete implementation in `robots/src/` (e.g., `sabo_robot.cpp`). The `GetRobot()` factory function returns the correct instance based on the compile-time `ROBOT_PLATFORM` macro, which also sets a `ROBOT_PLATFORM_<name>=1` preprocessor define for `#ifdef` guards.
+Each platform has a concrete implementation in `robots/src/` (e.g., `sabo_robot.cpp`). The `TryAutoDetectRobot()` function handles Stage 1 detection (Sabo/xBot via EEPROM), while `GetRobotByName()` resolves Stage 2 robots from the MetaService `Robot Firmware` register. No compile-time flags are used.
 
 ### Startup Flow
 
 1. HAL and ChibiOS kernel initialization (D-Cache disabled for Ethernet DMA)
 2. LWIP networking with DHCP (MAC address from ID EEPROM)
 3. LittleFS flash filesystem mount
-4. Platform detection via `GetRobot()` and carrier board ID verification
+4. Platform detection via `TryAutoDetectRobot()` (Stage 1: EEPROM) or `GetRobotByName()` (Stage 2: ROS MetaService)
 5. `InitPlatform()` -- hardware-specific setup (charger, motors, sensors)
 6. xbot I/O framework start
 7. `StartServices()` -- conditional service startup per platform
@@ -255,16 +238,16 @@ fw-openmower-v2/
 
 The OpenMower ecosystem spans multiple repositories:
 
-| Project | Description |
-|---|---|
-| [OpenMower](https://github.com/ClemensElflein/OpenMower) | Main project -- overview, documentation, and getting started |
-| [open_mower_ros](https://github.com/ClemensElflein/open_mower_ros) | ROS navigation stack (runs on Raspberry Pi CM4) |
-| [OpenMowerOS](https://github.com/ClemensElflein/OpenMowerOS) | Custom Linux image for the Raspberry Pi CM4 |
-| [xESC](https://github.com/ClemensElflein/xESC) | Open-source BLDC motor controller (VESC-compatible) |
-| [xbot_framework](https://github.com/ClemensElflein/xbot_framework) | Service framework used by this firmware |
-| [hw-openmower-yardforce](https://github.com/xtech/hw-openmower-yardforce) | YardForce carrier board hardware design |
-| [hw-openmower-sabo](https://github.com/xtech/hw-openmower-sabo) | Sabo / John Deere carrier board hardware design |
-| [hw-openmower-universal](https://github.com/xtech/hw-openmower-universal) | Universal carrier board hardware design |
+| Project                                                                   | Description                                                  |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| [OpenMower](https://github.com/ClemensElflein/OpenMower)                  | Main project -- overview, documentation, and getting started |
+| [open_mower_ros](https://github.com/ClemensElflein/open_mower_ros)        | ROS navigation stack (runs on Raspberry Pi CM4)              |
+| [OpenMowerOS](https://github.com/ClemensElflein/OpenMowerOS)              | Custom Linux image for the Raspberry Pi CM4                  |
+| [xESC](https://github.com/ClemensElflein/xESC)                            | Open-source BLDC motor controller (VESC-compatible)          |
+| [xbot_framework](https://github.com/ClemensElflein/xbot_framework)        | Service framework used by this firmware                      |
+| [hw-openmower-yardforce](https://github.com/xtech/hw-openmower-yardforce) | YardForce carrier board hardware design                      |
+| [hw-openmower-sabo](https://github.com/xtech/hw-openmower-sabo)           | Sabo / John Deere carrier board hardware design              |
+| [hw-openmower-universal](https://github.com/xtech/hw-openmower-universal) | Universal carrier board hardware design                      |
 
 ## Community
 
@@ -279,12 +262,12 @@ The OpenMower ecosystem spans multiple repositories:
 2. Create a feature branch
 3. Install pre-commit hooks: `pip install pre-commit && pre-commit install`
 4. Follow the code style (clang-format v14, Google base, 120-column limit)
-5. Ensure the build passes with `-Wall -Wextra -Werror` for your target platform
+5. Ensure the build passes with `-Wall -Wextra -Werror`
 6. Submit a pull request against `main`
 
-CI automatically runs pre-commit checks and builds all 6 platforms on every pull request. Tagged releases (`v*`) are automatically packaged and published to GitHub Releases.
+CI automatically runs pre-commit checks and builds the unified firmware on every pull request. Tagged releases (`v*`) are automatically packaged and published to GitHub Releases.
 
-To add support for a new robot platform, create a class inheriting from `Robot` or `MowerRobot` in `robots/`, implement the required virtual methods, and add the platform name to the `GetRobot()` factory.
+To add support for a new robot platform, create a class inheriting from `Robot` or `MowerRobot` in `robots/`, implement the required virtual methods (`BoardIsCompatible()` + `FirmwareName()` for Stage 2, or `IsAutoDetected()` for Stage 1), and register it in `robot.cpp`'s `GetRobotByName()` and/or `TryAutoDetectRobot()`.
 
 ## License
 

--- a/build-binary-and-upload-docker.sh
+++ b/build-binary-and-upload-docker.sh
@@ -2,11 +2,10 @@
 set -euo pipefail
 
 PRESET=${1:-Release}
-ROBOT=${2:-YardForce}
 
 mkdir -p build out
 
 cd build
-cmake .. --preset=$PRESET -DROBOT_PLATFORM=$ROBOT
+cmake .. --preset=$PRESET
 cd $PRESET
 cmake --build . --target upload -j$(nproc)

--- a/build-binary-and-upload.sh
+++ b/build-binary-and-upload.sh
@@ -2,11 +2,10 @@
 set -euo pipefail
 
 PRESET=${1:-Release}
-ROBOT=${2:-YardForce}
 
 mkdir -p build out
 
 cd build
-cmake .. --preset=$PRESET -DROBOT_PLATFORM=$ROBOT
+cmake .. --preset=$PRESET
 cd $PRESET
 cmake --build . --target upload -j$(nproc)

--- a/build-binary.sh
+++ b/build-binary.sh
@@ -2,14 +2,13 @@
 set -euo pipefail
 
 PRESET=${1:-Release}
-ROBOT=${2:-YardForce}
 
 mkdir -p build out
 
 cd build
-cmake .. --preset=$PRESET -DROBOT_PLATFORM=$ROBOT
+cmake .. --preset=$PRESET
 cd $PRESET
 make -j$(nproc)
 
-cp -v openmower.elf ../../out/openmower-$ROBOT.elf
-cp -v openmower.bin ../../out/openmower-$ROBOT.bin
+cp -v openmower.elf ../../out/openmower.elf
+cp -v openmower.bin ../../out/openmower.bin

--- a/build-binary.sh
+++ b/build-binary.sh
@@ -10,5 +10,5 @@ cmake .. --preset=$PRESET
 cd $PRESET
 make -j$(nproc)
 
-cp -v openmower.elf ../../out/openmower.elf
-cp -v openmower.bin ../../out/openmower.bin
+cp -v openmower-firmware.elf ../../out/openmower-firmware.elf
+cp -v openmower-firmware.bin ../../out/openmower-firmware.bin

--- a/robots/CMakeLists.txt
+++ b/robots/CMakeLists.txt
@@ -1,13 +1,4 @@
-set(ROBOT_PLATFORM "" CACHE STRING "Robot Platform to use (check the files in the src/ directory for options)")
-
-if(NOT ROBOT_PLATFORM)
-    message(FATAL_ERROR "You need to select a robot platform")
-else()
-    message("Selected Robot Platform: ${ROBOT_PLATFORM}")
-endif ()
-
-# find the platform sources and add them
+# All robot implementations are always compiled into the unified binary.
+# The correct robot is selected at runtime via hardware auto-detection (Stage 1)
+# or via the MetaService Robot Firmware register (Stage 2).
 file(GLOB_RECURSE PLATFORM_SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*")
-
-# Expose a preprocessor guard like ROBOT_PLATFORM_YardForce_V4=1 for #ifdef use
-add_compile_definitions(ROBOT_PLATFORM_${ROBOT_PLATFORM}=1)

--- a/robots/include/husq_310mkii_robot.hpp
+++ b/robots/include/husq_310mkii_robot.hpp
@@ -7,8 +7,11 @@
 
 class husq310MKIIRobot : public MowerRobot {
  public:
+  static bool BoardIsCompatible();
+  static const char* FirmwareName() {
+    return "Husqvarna-310MKII";
+  }
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   UARTDriver* GPS_GetUartPort() override {
 #ifndef STM32_UART_USE_USART6

--- a/robots/include/lyfco_e1600_robot.hpp
+++ b/robots/include/lyfco_e1600_robot.hpp
@@ -7,8 +7,11 @@
 
 class Lyfco_E1600Robot : public MowerRobot {
  public:
+  static bool BoardIsCompatible();
+  static const char* FirmwareName() {
+    return "Lyfco-E1600";
+  }
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   float Power_GetDefaultBatteryFullVoltage() override {
     return 7.0f * 4.2f;

--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -128,6 +128,12 @@ class Robot {
   }
 };
 
+// TODO: Introduce a VescMowerRobot intermediate class between MowerRobot
+// and the VESC-based robots (YardForce, Universal, ...).
+// VescMowerRobot would own the mower_motor_driver_ VescDriver and
+// the default InitMowerEsc(), while YardForce_V4Robot inherits directly from
+// MowerRobot with its own YFR4 driver (both implement MotorDriver).
+// This avoids an unused VescDriver member in non-VESC mower variants.
 class MowerRobot : public Robot {
  protected:
   void InitMotors();

--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -15,11 +15,19 @@ enum class ProtocolType : uint8_t;
 
 class Robot {
  public:
+  virtual ~Robot() = default;
   virtual void InitPlatform() = 0;
-  virtual bool IsHardwareSupported() = 0;
+  // Hardware detection is static per-class:
+  //   Phase 1 (unique hardware): static bool IsAutoDetected()
+  //   Phase 2 (name-configured): static bool BoardIsCompatible() + static const char* FirmwareName()
 
   virtual bool NeedsService(uint16_t id) {
     return id != xbot::service_ids::BMS;  // BMS is opt-in, all other services are required by default
+  }
+
+  // Return false to skip GpioInputDriver registration (e.g. robots with dedicated input hardware).
+  virtual bool NeedsGpioInputDriver() const {
+    return true;
   }
 
   virtual UARTDriver* GPS_GetUartPort() {
@@ -123,23 +131,25 @@ class Robot {
 class MowerRobot : public Robot {
  protected:
   void InitMotors();
+  virtual void InitMowerEsc();
 
   xbot::driver::motor::VescDriver left_motor_driver_{};
   xbot::driver::motor::VescDriver right_motor_driver_{};
-
-  // Select mower motor ESC by platform: YFR4 on YardForce_V4, VESC otherwise
-#if defined(ROBOT_PLATFORM_YardForce_V4)
-  using MowerEscDriver = xbot::driver::motor::YFR4escDriver;
-#else
-  using MowerEscDriver = xbot::driver::motor::VescDriver;
-#endif
-  MowerEscDriver mower_motor_driver_{};
+  xbot::driver::motor::VescDriver mower_motor_driver_{};
 
   DebugTCPInterface left_esc_driver_interface_{65102, &left_motor_driver_};
   DebugTCPInterface mower_esc_driver_interface_{65103, &mower_motor_driver_};
   DebugTCPInterface right_esc_driver_interface_{65104, &right_motor_driver_};
 };
 
-Robot* GetRobot();
+// Stage 1: returns non-null if the carrier board uniquely identifies one robot.
+Robot* TryAutoDetectRobot();
+
+// True if the board is known but requires Stage 2 (MetaService Robot Firmware register).
+bool BoardSupportsStage2();
+
+// Stage 2: instantiate robot by firmware name, validated against the current board.
+// Returns nullptr if name is invalid for this board.
+Robot* GetRobotByName(const char* name);
 
 #endif  // ROBOT_HPP

--- a/robots/include/sabo_robot.hpp
+++ b/robots/include/sabo_robot.hpp
@@ -26,12 +26,16 @@ class SaboRobot : public MowerRobot {
 
   SaboRobot();
 
+  static bool IsAutoDetected();
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   bool NeedsService(uint16_t id) override {
     if (id == xbot::service_ids::BMS) return hardware_config.bms != nullptr;
     return Robot::NeedsService(id);
+  }
+
+  bool NeedsGpioInputDriver() const override {
+    return false;
   }
 
   UARTDriver* GPS_GetUartPort() override {

--- a/robots/include/universal_5s_robot.hpp
+++ b/robots/include/universal_5s_robot.hpp
@@ -9,6 +9,13 @@
  */
 class Universal5SRobot : public UniversalRobot {
  public:
+  static bool BoardIsCompatible() {
+    return UniversalRobot::BoardIsCompatible();
+  }
+  static const char* FirmwareName() {
+    return "Universal-5S";
+  }
+
   float Power_GetDefaultBatteryFullVoltage() override {
     return 5.0f * 4.2f;
   }

--- a/robots/include/universal_7s_robot.hpp
+++ b/robots/include/universal_7s_robot.hpp
@@ -9,6 +9,13 @@
  */
 class Universal7SRobot : public UniversalRobot {
  public:
+  static bool BoardIsCompatible() {
+    return UniversalRobot::BoardIsCompatible();
+  }
+  static const char* FirmwareName() {
+    return "Universal-7S";
+  }
+
   float Power_GetDefaultBatteryFullVoltage() override {
     return 7.0f * 4.2f;
   }

--- a/robots/include/universal_8s_robot.hpp
+++ b/robots/include/universal_8s_robot.hpp
@@ -9,6 +9,9 @@
  */
 class Universal8SRobot : public UniversalRobot {
  public:
+  static const char* FirmwareName() {
+    return "Universal-8S";
+  }
   float Power_GetDefaultBatteryFullVoltage() override {
     return 8.0f * 4.2f;
   }

--- a/robots/include/universal_robot.hpp
+++ b/robots/include/universal_robot.hpp
@@ -11,8 +11,8 @@
  */
 class UniversalRobot : public MowerRobot {
  public:
+  static bool BoardIsCompatible();
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   float Power_GetDefaultChargeCurrent() override {
     return 0.5;

--- a/robots/include/worx_robot.hpp
+++ b/robots/include/worx_robot.hpp
@@ -11,8 +11,11 @@ using namespace xbot::driver::input;
 
 class WorxRobot : public MowerRobot {
  public:
+  static bool BoardIsCompatible();
+  static const char* FirmwareName() {
+    return "Worx";
+  }
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   float Power_GetDefaultBatteryFullVoltage() override {
     return 5.0f * 4.2f;

--- a/robots/include/xbot_robot.hpp
+++ b/robots/include/xbot_robot.hpp
@@ -11,8 +11,8 @@ using xbot::driver::motor::PwmMotorDriver;
 
 class xBotRobot : public Robot {
  public:
+  static bool IsAutoDetected();
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   bool NeedsService(uint16_t id) {
     return id != xbot::service_ids::MOWER;

--- a/robots/include/yardforce_robot.hpp
+++ b/robots/include/yardforce_robot.hpp
@@ -9,8 +9,11 @@
 
 class YardForceRobot : public MowerRobot {
  public:
+  static bool BoardIsCompatible();
+  static const char* FirmwareName() {
+    return "YardForce";
+  }
   void InitPlatform() override;
-  bool IsHardwareSupported() override;
 
   UARTDriver* GPS_GetUartPort() override {
 #ifndef STM32_UART_USE_USART6

--- a/robots/include/yardforce_v4_robot.hpp
+++ b/robots/include/yardforce_v4_robot.hpp
@@ -10,11 +10,14 @@
 // Selection happens at runtime (unified binary) via BoardIsCompatible().
 class YardForce_V4Robot : public YardForceRobot {
  public:
-  static bool BoardIsCompatible();
   static const char* FirmwareName() {
     return "YardForce-V4";
   }
-  void InitMowerEsc() override;
+  void InitMowerEsc() override {
+    yfr4_mower_driver_.SetUART(&UARTD2, 115200);
+    yfr4_mower_debug_.Start();
+    mower_service.SetDriver(&yfr4_mower_driver_);
+  }
 
  private:
   xbot::driver::motor::YFR4escDriver yfr4_mower_driver_{};

--- a/robots/include/yardforce_v4_robot.hpp
+++ b/robots/include/yardforce_v4_robot.hpp
@@ -1,13 +1,24 @@
 #ifndef YARDFORCE_V4_ROBOT_HPP
 #define YARDFORCE_V4_ROBOT_HPP
 
+#include <drivers/motor/yfr4esc/YFR4escDriver.h>
+
 #include "yardforce_robot.hpp"
 
 // YardForce V4 uses the YFR4 ESC for the mower motor instead of VESC.
-// The platform selection is done at compile-time via ROBOT_PLATFORM=YardForce_V4:
-//  - MowerRobot picks YFR4escDriver via #ifdef ROBOT_PLATFORM_YardForce_V4
-//  - robot.cpp instantiates this class via CREATE_ROBOT(YardForce_V4)
-// Apart from the mower ESC, everything else is identical to YardForceRobot.
-class YardForce_V4Robot : public YardForceRobot {};
+// Inherits common YardForce logic, overrides InitMowerEsc() to wire YFR4.
+// Selection happens at runtime (unified binary) via BoardIsCompatible().
+class YardForce_V4Robot : public YardForceRobot {
+ public:
+  static bool BoardIsCompatible();
+  static const char* FirmwareName() {
+    return "YardForce-V4";
+  }
+  void InitMowerEsc() override;
+
+ private:
+  xbot::driver::motor::YFR4escDriver yfr4_mower_driver_{};
+  DebugTCPInterface yfr4_mower_debug_{65103, &yfr4_mower_driver_};
+};
 
 #endif  // YARDFORCE_V4_ROBOT_HPP

--- a/robots/src/husq_310mkii_robot.cpp
+++ b/robots/src/husq_310mkii_robot.cpp
@@ -8,7 +8,7 @@ void husq310MKIIRobot::InitPlatform() {
   power_service.SetDriver(&charger_);
 }
 
-bool husq310MKIIRobot::IsHardwareSupported() {
+bool husq310MKIIRobot::BoardIsCompatible() {
   return (strncmp("hw-openmower-310mk2", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0) &&
          (carrier_board_info.version_major == 1);
 }

--- a/robots/src/lyfco_e1600_robot.cpp
+++ b/robots/src/lyfco_e1600_robot.cpp
@@ -8,7 +8,7 @@ void Lyfco_E1600Robot::InitPlatform() {
   power_service.SetDriver(&charger_);
 }
 
-bool Lyfco_E1600Robot::IsHardwareSupported() {
+bool Lyfco_E1600Robot::BoardIsCompatible() {
   // First batch of universal boards have a non-working EEPROM
   // so we assume that the firmware is compatible, if the xcore is the first batch and no carrier was found.
   if (carrier_board_info.board_info_version == 0 &&

--- a/robots/src/robot.cpp
+++ b/robots/src/robot.cpp
@@ -1,5 +1,7 @@
 #include "../include/robot.hpp"
 
+#include <cstring>
+#include <globals.hpp>
 #include <services.hpp>
 
 #include "../include/husq_310mkii_robot.hpp"
@@ -13,24 +15,50 @@
 #include "../include/yardforce_robot.hpp"
 #include "../include/yardforce_v4_robot.hpp"
 
-#define EXPAND(x) x
-#define ROBOT_CLASS_NAME(platform) platform##Robot
-#define CREATE_ROBOT(platform) new EXPAND(ROBOT_CLASS_NAME(platform))()
+// ── Public detection API ──────────────────────────────────────────────────────
 
-Robot* GetRobot() {
-  // TODO: This should look at the flash to determine the mower type.
-  return CREATE_ROBOT(ROBOT_PLATFORM);
+Robot* TryAutoDetectRobot() {
+  if (SaboRobot::IsAutoDetected()) return new SaboRobot{};
+  if (xBotRobot::IsAutoDetected()) return new xBotRobot{};
+  return nullptr;
 }
+
+bool BoardSupportsStage2() {
+  return YardForceRobot::BoardIsCompatible() || YardForce_V4Robot::BoardIsCompatible() ||
+         Universal5SRobot::BoardIsCompatible() || Universal7SRobot::BoardIsCompatible() ||
+         WorxRobot::BoardIsCompatible() || Lyfco_E1600Robot::BoardIsCompatible();
+}
+
+Robot* GetRobotByName(const char* name) {
+  if (YardForceRobot::BoardIsCompatible() && strncmp(name, YardForceRobot::FirmwareName(), 50) == 0)
+    return new YardForceRobot{};
+  if (YardForce_V4Robot::BoardIsCompatible() && strncmp(name, YardForce_V4Robot::FirmwareName(), 50) == 0)
+    return new YardForce_V4Robot{};
+  if (Universal5SRobot::BoardIsCompatible() && strncmp(name, Universal5SRobot::FirmwareName(), 50) == 0)
+    return new Universal5SRobot{};
+  if (Universal7SRobot::BoardIsCompatible() && strncmp(name, Universal7SRobot::FirmwareName(), 50) == 0)
+    return new Universal7SRobot{};
+  if (WorxRobot::BoardIsCompatible() && strncmp(name, WorxRobot::FirmwareName(), 50) == 0) return new WorxRobot{};
+  if (Lyfco_E1600Robot::BoardIsCompatible() && strncmp(name, Lyfco_E1600Robot::FirmwareName(), 50) == 0)
+    return new Lyfco_E1600Robot{};
+  return nullptr;
+}
+
+// ── MowerRobot motor initialisation ──────────────────────────────────────────
 
 void MowerRobot::InitMotors() {
   left_motor_driver_.SetUART(&UARTD1, 115200);
   right_motor_driver_.SetUART(&UARTD4, 115200);
-  mower_motor_driver_.SetUART(&UARTD2, 115200);
 
   left_esc_driver_interface_.Start();
   right_esc_driver_interface_.Start();
-  mower_esc_driver_interface_.Start();
 
   diff_drive.SetDrivers(&left_motor_driver_, &right_motor_driver_);
+  InitMowerEsc();
+}
+
+void MowerRobot::InitMowerEsc() {
+  mower_motor_driver_.SetUART(&UARTD2, 115200);
+  mower_esc_driver_interface_.Start();
   mower_service.SetDriver(&mower_motor_driver_);
 }

--- a/robots/src/robot.cpp
+++ b/robots/src/robot.cpp
@@ -26,7 +26,8 @@ Robot* TryAutoDetectRobot() {
 bool BoardSupportsStage2() {
   return YardForceRobot::BoardIsCompatible() || YardForce_V4Robot::BoardIsCompatible() ||
          Universal5SRobot::BoardIsCompatible() || Universal7SRobot::BoardIsCompatible() ||
-         WorxRobot::BoardIsCompatible() || Lyfco_E1600Robot::BoardIsCompatible();
+         WorxRobot::BoardIsCompatible() || Lyfco_E1600Robot::BoardIsCompatible() ||
+         husq310MKIIRobot::BoardIsCompatible();
 }
 
 Robot* GetRobotByName(const char* name) {
@@ -41,6 +42,8 @@ Robot* GetRobotByName(const char* name) {
   if (WorxRobot::BoardIsCompatible() && strncmp(name, WorxRobot::FirmwareName(), 50) == 0) return new WorxRobot{};
   if (Lyfco_E1600Robot::BoardIsCompatible() && strncmp(name, Lyfco_E1600Robot::FirmwareName(), 50) == 0)
     return new Lyfco_E1600Robot{};
+  if (husq310MKIIRobot::BoardIsCompatible() && strncmp(name, husq310MKIIRobot::FirmwareName(), 50) == 0)
+    return new husq310MKIIRobot{};
   return nullptr;
 }
 

--- a/robots/src/robot.cpp
+++ b/robots/src/robot.cpp
@@ -26,8 +26,8 @@ Robot* TryAutoDetectRobot() {
 bool BoardSupportsStage2() {
   return YardForceRobot::BoardIsCompatible() || YardForce_V4Robot::BoardIsCompatible() ||
          Universal5SRobot::BoardIsCompatible() || Universal7SRobot::BoardIsCompatible() ||
-         WorxRobot::BoardIsCompatible() || Lyfco_E1600Robot::BoardIsCompatible() ||
-         husq310MKIIRobot::BoardIsCompatible();
+         Universal8SRobot::BoardIsCompatible() || WorxRobot::BoardIsCompatible() ||
+         Lyfco_E1600Robot::BoardIsCompatible() || husq310MKIIRobot::BoardIsCompatible();
 }
 
 Robot* GetRobotByName(const char* name) {
@@ -39,6 +39,8 @@ Robot* GetRobotByName(const char* name) {
     return new Universal5SRobot{};
   if (Universal7SRobot::BoardIsCompatible() && strncmp(name, Universal7SRobot::FirmwareName(), 50) == 0)
     return new Universal7SRobot{};
+  if (Universal8SRobot::BoardIsCompatible() && strncmp(name, Universal8SRobot::FirmwareName(), 50) == 0)
+    return new Universal8SRobot{};
   if (WorxRobot::BoardIsCompatible() && strncmp(name, WorxRobot::FirmwareName(), 50) == 0) return new WorxRobot{};
   if (Lyfco_E1600Robot::BoardIsCompatible() && strncmp(name, Lyfco_E1600Robot::FirmwareName(), 50) == 0)
     return new Lyfco_E1600Robot{};

--- a/robots/src/sabo_robot.cpp
+++ b/robots/src/sabo_robot.cpp
@@ -44,7 +44,7 @@ void SaboRobot::InitPlatform() {
   cover_ui_.Start();
 }
 
-bool SaboRobot::IsHardwareSupported() {
+bool SaboRobot::IsAutoDetected() {
   // Accept Sabo 0.1 through 0.5.x boards
   if (strncmp("hw-openmower-sabo", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0 &&
       strncmp("xcore", board_info.board_id, sizeof(board_info.board_id)) == 0 && board_info.version_major == 1 &&

--- a/robots/src/universal_robot.cpp
+++ b/robots/src/universal_robot.cpp
@@ -8,7 +8,7 @@ void UniversalRobot::InitPlatform() {
   power_service.SetDriver(GetCharger());
 }
 
-bool UniversalRobot::IsHardwareSupported() {
+bool UniversalRobot::BoardIsCompatible() {
   // First batch of universal boards have a non-working EEPROM
   // so we assume that the firmware is compatible, if the xcore is the first batch and no carrier was found.
   if (carrier_board_info.board_info_version == 0 &&

--- a/robots/src/worx_robot.cpp
+++ b/robots/src/worx_robot.cpp
@@ -3,6 +3,8 @@
 #include <globals.hpp>
 #include <services.hpp>
 
+#include "../include/universal_robot.hpp"
+
 void WorxRobot::InitPlatform() {
   InitMotors();
   charger_.setI2C(&I2CD1);
@@ -10,17 +12,6 @@ void WorxRobot::InitPlatform() {
   input_service.RegisterInputDriver("worx", &worx_driver_);
 }
 
-bool WorxRobot::IsHardwareSupported() {
-  // First batch of universal boards have a non-working EEPROM
-  // so we assume that the firmware is compatible, if the xcore is the first batch and no carrier was found.
-  if (carrier_board_info.board_info_version == 0 &&
-      strncmp("N/A", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0 &&
-      strncmp("xcore", board_info.board_id, sizeof(board_info.board_id)) == 0 &&
-      (board_info.version_major < 1 || (board_info.version_major == 1 && board_info.version_minor < 1) ||
-       (board_info.version_major == 1 && board_info.version_minor == 1 && board_info.version_patch <= 7))) {
-    return true;
-  }
-
-  // Else, we accept universal boards
-  return strncmp("hw-openmower-universal", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0;
+bool WorxRobot::BoardIsCompatible() {
+  return UniversalRobot::BoardIsCompatible();
 }

--- a/robots/src/xbot_robot.cpp
+++ b/robots/src/xbot_robot.cpp
@@ -88,7 +88,7 @@ void xBotRobot::InitPlatform() {
   power_service.SetDriver(&charger_);
 }
 
-bool xBotRobot::IsHardwareSupported() {
+bool xBotRobot::IsAutoDetected() {
   // Accept YardForce 1.x.x boards
   return strncmp("hw-xbot-mainboard", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0 &&
          carrier_board_info.version_major == 0;

--- a/robots/src/yardforce_robot.cpp
+++ b/robots/src/yardforce_robot.cpp
@@ -7,6 +7,8 @@
 #include <globals.hpp>
 #include <services.hpp>
 
+#include "../include/yardforce_v4_robot.hpp"
+
 void YardForceRobot::InitPlatform() {
   InitMotors();
   charger_.setI2C(&I2CD1);
@@ -24,19 +26,10 @@ void YardForceRobot::InitPlatform() {
   palSetLine(LINE_GPIO4);
 }
 
-bool YardForceRobot::IsHardwareSupported() {
-  // Accept YardForce 1.x.x boards
-  if (strncmp("hw-openmower-yardforce", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0 &&
-      carrier_board_info.version_major == 1) {
-    return true;
-  }
-
-  // Accept early testing boards
-  if (strncmp("hw-xbot-devkit", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0) {
-    return true;
-  }
-
-  return false;
+bool YardForceRobot::BoardIsCompatible() {
+  return (strncmp("hw-openmower-yardforce", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0 &&
+          carrier_board_info.version_major == 1) ||
+         strncmp("hw-xbot-devkit", carrier_board_info.board_id, sizeof(carrier_board_info.board_id)) == 0;
 }
 
 void YardForceRobot::RegisterAdcSensors() {
@@ -86,4 +79,14 @@ void YardForceRobot::RegisterAdcSensors() {
       },
       const_cast<float*>(&ADC_BATTERY_VOLTAGE_SCALE), EmaFilterConfig{0.3f, 0.7f, 0.5f, true});
   RegisterConversionGroup(v_battery_cg);
+}
+
+bool YardForce_V4Robot::BoardIsCompatible() {
+  return YardForceRobot::BoardIsCompatible();
+}
+
+void YardForce_V4Robot::InitMowerEsc() {
+  yfr4_mower_driver_.SetUART(&UARTD2, 115200);
+  yfr4_mower_debug_.Start();
+  mower_service.SetDriver(&yfr4_mower_driver_);
 }

--- a/robots/src/yardforce_robot.cpp
+++ b/robots/src/yardforce_robot.cpp
@@ -7,8 +7,6 @@
 #include <globals.hpp>
 #include <services.hpp>
 
-#include "../include/yardforce_v4_robot.hpp"
-
 void YardForceRobot::InitPlatform() {
   InitMotors();
   charger_.setI2C(&I2CD1);
@@ -79,14 +77,4 @@ void YardForceRobot::RegisterAdcSensors() {
       },
       const_cast<float*>(&ADC_BATTERY_VOLTAGE_SCALE), EmaFilterConfig{0.3f, 0.7f, 0.5f, true});
   RegisterConversionGroup(v_battery_cg);
-}
-
-bool YardForce_V4Robot::BoardIsCompatible() {
-  return YardForceRobot::BoardIsCompatible();
-}
-
-void YardForce_V4Robot::InitMowerEsc() {
-  yfr4_mower_driver_.SetUART(&UARTD2, 115200);
-  yfr4_mower_debug_.Start();
-  mower_service.SetDriver(&yfr4_mower_driver_);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,10 @@ int main() {
   SYSVIEW_ChibiOS_Start(STM32_SYS_CK, STM32_SYS_CK, "I#15=SysTick");
 #endif
 
+#ifndef RELEASE_BUILD
+  chThdSleepMilliseconds(1000);
+#endif
+
   /*
    * InitGlobals() sets up global variables shared by threads. (e.g. mutex)
    * InitHeartbeat() starts the heartbeat timer to blink an LED as long as the
@@ -103,29 +107,46 @@ int main() {
     }
   }
 
-  robot = GetRobot();
-  if (!robot->IsHardwareSupported()) {
-    SetStatusLedMode(LED_MODE_BLINK_FAST);
+  // Io and MetaService always start before robot detection so that
+  // Stage 2 (ROS-assisted config) can communicate from the beginning.
+  xbot::service::Io::start();
+  meta_service.start();
+
+  // Stage 1: unique-board robots self-identify from carrier EEPROM.
+  robot = TryAutoDetectRobot();
+
+  if (robot == nullptr) {
+    if (!BoardSupportsStage2()) {
+      // Completely unknown hardware — refuse to boot.
+      SetStatusLedMode(LED_MODE_BLINK_FAST);
+      SetStatusLedColor(RED);
+      while (true) {
+        ULOG_ERROR("Unknown hardware, cannot boot: carrier=%s v%u.%u.%u  core=%s v%u.%u.%u",
+                   carrier_board_info.board_id, carrier_board_info.version_major, carrier_board_info.version_minor,
+                   carrier_board_info.version_patch, board_info.board_id, board_info.version_major,
+                   board_info.version_minor, board_info.version_patch);
+        chThdSleep(TIME_S2I(1));
+      }
+    }
+
+    // Stage 2: board is known but needs ROS to supply the firmware variant.
+    SetStatusLedMode(LED_MODE_BLINK_SLOW);
     SetStatusLedColor(RED);
 
-    etl::string<100> info{};
-    info += "Carrier board not supported for this firmware: ";
-    info += carrier_board_info.board_id;
-    info += " v";
-    etl::to_string(carrier_board_info.version_major, info, true);
-    info += ".";
-    etl::to_string(carrier_board_info.version_minor, info, true);
-    info += ".";
-    etl::to_string(carrier_board_info.version_patch, info, true);
-
-    while (true) {
-      ULOG_ERROR(info.c_str());
-      chThdSleep(TIME_S2I(1));
+    while (robot == nullptr) {
+      ULOG_INFO("Waiting for Robot Firmware configuration via MetaService (carrier=%s)...",
+                carrier_board_info.board_id);
+      if (meta_service.HasRobotFirmware()) {
+        robot = GetRobotByName(meta_service.GetRobotFirmware());
+        if (robot == nullptr) {
+          ULOG_ERROR("Robot Firmware '%s' is invalid for this hardware, ignoring", meta_service.GetRobotFirmware());
+        }
+      }
+      chThdSleepMilliseconds(1000);
     }
   }
 
   robot->InitPlatform();
-  xbot::service::Io::start();
   StartServices();
   SetStatusLedColor(GREEN);
   DispatchEvents();

--- a/src/services.cpp
+++ b/src/services.cpp
@@ -8,6 +8,7 @@
 #endif
 #include "globals.hpp"
 
+MetaService meta_service{xbot::service_ids::META};
 EmergencyService emergency_service{xbot::service_ids::EMERGENCY};
 DiffDriveService diff_drive{xbot::service_ids::DIFF_DRIVE};
 MowerService mower_service{xbot::service_ids::MOWER};
@@ -25,14 +26,15 @@ void StartServices() {
   }
 
   if (robot->NeedsService(xbot::service_ids::INPUT)) {
-#ifndef ROBOT_PLATFORM_Sabo
-    input_service.RegisterInputDriver("gpio", new GpioInputDriver{});
-#endif
+    if (robot->NeedsGpioInputDriver()) {
+      input_service.RegisterInputDriver("gpio", new GpioInputDriver{});
+    }
 #ifdef DEBUG_BUILD
     input_service.RegisterInputDriver("simulated", new SimulatedInputDriver{});
 #endif
   }
 
+  // meta_service is always started early in main() before robot detection.
   START_IF_NEEDED(bms_service, BMS)
 
   if (robot->NeedsService(xbot::service_ids::INPUT)) {

--- a/src/services.hpp
+++ b/src/services.hpp
@@ -8,9 +8,11 @@
 #include "services/high_level_service/high_level_service.hpp"
 #include "services/imu_service/imu_service.hpp"
 #include "services/input_service/input_service.hpp"
+#include "services/meta_service/meta_service.hpp"
 #include "services/mower_service/mower_service.hpp"
 #include "services/power_service/power_service.hpp"
 
+extern MetaService meta_service;
 extern EmergencyService emergency_service;
 extern DiffDriveService diff_drive;
 extern MowerService mower_service;

--- a/src/services/meta_service/meta_service.cpp
+++ b/src/services/meta_service/meta_service.cpp
@@ -1,0 +1,19 @@
+#include "meta_service.hpp"
+
+#include <git_version.h>
+
+#include <cstring>
+#include <xbot-service/Io.hpp>
+
+void MetaService::RPCGetFirmwareVersion(uint16_t call_id, char* data, uint16_t* response_length) {
+  size_t len = strlen(BUILD_VERSION);
+  if (len > *response_length) len = *response_length;
+  memcpy(data, BUILD_VERSION, len);
+  *response_length = static_cast<uint16_t>(len);
+  SendRpcResponse(call_id, xbot::datatypes::RpcStatus::SUCCESS, data, len * sizeof(char));
+}
+
+void MetaService::RPCGetMajorVersion(uint16_t call_id) {
+  uint16_t v = kFirmwareMajorVersion;
+  SendRpcResponse(call_id, xbot::datatypes::RpcStatus::SUCCESS, &v, sizeof(v));
+}

--- a/src/services/meta_service/meta_service.hpp
+++ b/src/services/meta_service/meta_service.hpp
@@ -1,0 +1,33 @@
+#ifndef META_SERVICE_HPP
+#define META_SERVICE_HPP
+
+#include <MetaServiceBase.hpp>
+
+// Bump when firmware and ROS side are no longer compatible.
+// ROS refuses to start if its copy of this constant doesn't match.
+static constexpr uint16_t kFirmwareMajorVersion = 1;
+
+class MetaService : public MetaServiceBase {
+ public:
+  explicit MetaService(uint16_t service_id) : MetaServiceBase(service_id, wa, sizeof(wa)) {
+  }
+
+  // Thread-safe: acquire load on the generated .valid field.
+  bool HasRobotFirmware() const {
+    return __atomic_load_n(&RobotFirmware.valid, __ATOMIC_ACQUIRE);
+  }
+
+  // Valid only after HasRobotFirmware() returns true.
+  const char* GetRobotFirmware() const {
+    return RobotFirmware.value;
+  }
+
+ protected:
+  void RPCGetFirmwareVersion(uint16_t call_id, char* data, uint16_t* response_length) override;
+  void RPCGetMajorVersion(uint16_t call_id) override;
+
+ private:
+  THD_WORKING_AREA(wa, 512){};
+};
+
+#endif  // META_SERVICE_HPP


### PR DESCRIPTION
## Summary

- Replaces 8 per-robot compile-time builds with a single `openmower.bin` that selects the robot variant at runtime
- Two-stage detection: stage 1 via EEPROM (Sabo/xBot auto-detect), stage 2 via MetaService `Robot Firmware` register (ROS pushes the variant name for YardForce/Universal boards)
- Each robot class owns its detection logic as static methods (`IsAutoDetected()` / `BoardIsCompatible()` + `FirmwareName()`) — no more centralized board classifier helpers
- New MetaService (service ID 11): `GetFirmwareVersion` RPC, `GetMajorVersion` RPC, `Robot Firmware` optional register
- Dockerfile and build scripts simplified to one build; ccache removed
- xbot_framework submodule bumped to v0.1.3 (RPC support); codegen template fixed for no-parameter RPC functions

## Firmware names (stage 2)

| Name | Board |
|---|---|
| `YardForce` | YardForce V3 |
| `YardForce-V4` | YardForce V4 |
| `Universal-5S` | Universal 5S |
| `Universal-7S` | Universal 7S |
| `Universal-8S` | Universal 8S |
| `Worx` | Worx |
| `Lyfco-E1600` | Lyfco E1600 |
| `Husqvarna-310MKII` | Husqvarna Automower 310 Mark II |

## Test plan

- [x] Build produces single `openmower.bin` without `ROBOT_PLATFORM` flag
- [x] Sabo/xBot boards auto-detect from EEPROM (stage 1, no MetaService needed)
- [ ] Unknown board → fast-blink red LED, error log loop
- [ ] Known board without ROS config → slow-blink red, waits for `Robot Firmware` register
- [ ] ROS pushes valid name → robot initializes, LED goes green
- [ ] ROS pushes invalid name → error logged, keeps waiting
- [ ] `GetFirmwareVersion` RPC returns build version string
- [ ] `GetMajorVersion` RPC returns 1

## Open Issues
- [ ] `openmower update-firmware` will fail because of `FIRMWARE` .env var based composition of the filename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added automatic robot and board detection with firmware-based fallback selection across supported platforms.
- Added firmware identity and version reporting.
- Added YardForce V4 motor control and debugging support.

## Improvements
- Input drivers are initialized only when required.
- Improved startup handling for unsupported or unrecognized hardware.

## Build & Release
- Unified firmware builds now produce consistent firmware files and memory reports.
- Added a development debugging configuration for STM32H723ZG.
- Updated release artifacts to use unified firmware naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->