### PR TITLE
Enable 12V Aux PSU by default

### DIFF
--- a/robots/src/yardforce_robot.cpp
+++ b/robots/src/yardforce_robot.cpp
@@ -12,6 +12,10 @@ void YardForceRobot::InitPlatform() {
 #endif
   input_service.RegisterInputDriver("yf_cover_ui", &yf_cover_ui_);
   yf_cover_ui_.Start(&UARTD7);
+
+  // Enable aux power supply
+  palSetLineMode(LINE_GPIO4, PAL_MODE_OUTPUT_PUSHPULL);
+  palSetLine(LINE_GPIO4);
 }
 
 bool YardForceRobot::IsHardwareSupported() {


### PR DESCRIPTION
Enables the 12V Aux PSU by default on YardForce boards. Not sure if we should make that configurable through ROS or something.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved robot startup by enabling an auxiliary power supply during initialization, helping hardware come up more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->