### PR TITLE
MowerService: signed mow-motor speed and signed RPM (v2)

### DIFF
--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -18,11 +18,15 @@ void MowerService::OnCreate() {
 
 bool MowerService::OnStart() {
   mower_duty_ = 0;
+  mower_duty_target_ = 0;
+  ramping_ = false;
   return true;
 }
 
 void MowerService::OnStop() {
   mower_duty_ = 0;
+  mower_duty_target_ = 0;
+  ramping_ = false;
   esc_ever_connected_ = false;
 }
 
@@ -33,6 +37,26 @@ void MowerService::tick() {
   if (xbot::service::system::getTimeMicros() - last_duty_received_micros_ > 10'000'000) {
     // it's ok to set it here, because we know that duty_set_ is false (we're in a timeout after all)
     mower_duty_ = 0;
+    mower_duty_target_ = 0;
+    ramping_ = false;
+  }
+
+  // Ramp toward the target during a reversal (flagged in OnMowerSpeedChanged) so
+  // a hard direction flip doesn't draw a large current spike. Timed off the real
+  // clock, so it stays ~5 s regardless of the tick rate.
+  if (ramping_) {
+    constexpr float kRampRatePerSecond = 2.0f / 5.0f;  // full +-1 reversal (range 2.0) over 5 s
+    const uint32_t now = xbot::service::system::getTimeMicros();
+    const float max_step = kRampRatePerSecond * (now - last_ramp_micros_) / 1'000'000.0f;
+    last_ramp_micros_ = now;
+    const float delta = mower_duty_target_ - mower_duty_;
+    if (std::fabs(delta) <= max_step) {
+      mower_duty_ = mower_duty_target_;
+      ramping_ = false;
+    } else {
+      mower_duty_ += (delta > 0.0f) ? max_step : -max_step;
+    }
+    duty_sent_ = false;  // force this step out even if a command already sent this tick
   }
 
   if (!duty_sent_) {
@@ -53,6 +77,8 @@ void MowerService::tick() {
   if (xbot::service::system::getTimeMicros() - last_valid_esc_state_micros_ > 1'000'000 || !esc_state_valid_) {
     // No recent update received (or none at all)
     mower_duty_ = 0;
+    mower_duty_target_ = 0;
+    ramping_ = false;
     SendMowerStatus(static_cast<uint8_t>(MotorDriver::ESCState::ESCStatus::ESC_STATUS_DISCONNECTED));
   } else {
     // We got recent data, send it
@@ -62,7 +88,8 @@ void MowerService::tick() {
     SendMowerStatus(static_cast<uint8_t>(esc_state_.status));
     SendMowerMotorTemperature(esc_state_.temperature_motor);
     SendMowerRunning(std::fabs(esc_state_.rpm) > 0);
-    SendMowerMotorRPM(esc_state_.rpm);
+    // Sign by measured direction; not sign(rpm) (YFR4esc reports unsigned rpm).
+    SendMowerMotorRPM(esc_state_.direction > 0.5f ? -std::fabs(esc_state_.rpm) : std::fabs(esc_state_.rpm));
   }
   CommitTransaction();
 
@@ -90,15 +117,37 @@ void MowerService::SetDuty() {
   duty_sent_ = true;
 }
 
-void MowerService::OnMowerEnabledChanged(const uint8_t& new_value) {
+void MowerService::OnMowerSpeedChanged(const float& new_value) {
   chMtxLock(&mtx);
   last_duty_received_micros_ = xbot::service::system::getTimeMicros();
-  if (new_value) {
-    mower_duty_ = 1.0;
-  } else {
-    mower_duty_ = 0;
+  // Normalized speed in [-1, 1]: sign = direction, magnitude = duty, 0 = off.
+  const float target = new_value < -1.0f ? -1.0f : (new_value > 1.0f ? 1.0f : new_value);
+  mower_duty_target_ = target;
+
+  // Ramp only when the blade is physically spinning the opposite way to the new
+  // command, judged from ESC telemetry (not the last command, which misses a
+  // stop-then-reverse). direction is meaningless at standstill, so require spin.
+  chMtxLock(&state_mutex_);  // esc_state_ is written by ESCCallback under state_mutex_
+  const float esc_rpm = esc_state_.rpm;
+  const bool esc_reverse = esc_state_.direction > 0.5f;
+  chMtxUnlock(&state_mutex_);
+  constexpr float kSpinningRpm = 100.0f;  // raw ESC rpm; just rejects standstill noise
+  const bool spinning = std::fabs(esc_rpm) > kSpinningRpm;
+  const bool reversal_under_load = spinning && target != 0.0f && (esc_reverse != (target < 0.0f));
+
+  if (target == 0.0f) {
+    // Stop immediately (aborts any ramp).
+    ramping_ = false;
+    mower_duty_ = 0.0f;
+  } else if (!ramping_ && reversal_under_load) {
+    // Reversal while spinning: ramp it in tick() instead of snapping.
+    ramping_ = true;
+    last_ramp_micros_ = last_duty_received_micros_;  // ramp clock starts now
+  } else if (!ramping_) {
+    mower_duty_ = target;
   }
-  if (!duty_sent_) {
+
+  if (!ramping_ && !duty_sent_) {
     SetDuty();
   }
   chMtxUnlock(&mtx);
@@ -115,6 +164,8 @@ void MowerService::OnEmergencyChangedEvent() {
   }
   chMtxLock(&mtx);
   mower_duty_ = 0;
+  mower_duty_target_ = 0;
+  ramping_ = false;
   // Instantly send the 0 duty cycle
   SetDuty();
   chMtxUnlock(&mtx);

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -138,6 +138,10 @@ void MowerService::OnMowerSpeedChanged(const float& new_value) {
     // Stop immediately (aborts any ramp).
     ramping_ = false;
     mower_duty_ = 0.0f;
+  } else if (ramping_ && !reversal_under_load) {
+    // Cancel ramp: new command matches current ESC direction, apply immediately.
+    ramping_ = false;
+    mower_duty_ = target;
   } else if (!ramping_ && reversal_under_load) {
     // Reversal while spinning: ramp it in tick() instead of snapping.
     ramping_ = true;

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -88,8 +88,7 @@ void MowerService::tick() {
     SendMowerStatus(static_cast<uint8_t>(esc_state_.status));
     SendMowerMotorTemperature(esc_state_.temperature_motor);
     SendMowerRunning(std::fabs(esc_state_.rpm) > 0);
-    // Sign by measured direction; not sign(rpm) (YFR4esc reports unsigned rpm).
-    SendMowerMotorRPM(esc_state_.direction > 0.5f ? -std::fabs(esc_state_.rpm) : std::fabs(esc_state_.rpm));
+    SendMowerMotorRPM(esc_state_.rpm);
   }
   CommitTransaction();
 

--- a/src/services/mower_service/mower_service.hpp
+++ b/src/services/mower_service/mower_service.hpp
@@ -48,7 +48,7 @@ class MowerService : public MowerServiceBase {
   void ESCCallback(const MotorDriver::ESCState& state);
 
  protected:
-  void OnMowerEnabledChanged(const uint8_t& new_value) override;
+  void OnMowerSpeedChanged(const float& new_value) override;
 
  private:
   THD_WORKING_AREA(wa, 1024){};
@@ -57,7 +57,10 @@ class MowerService : public MowerServiceBase {
   uint32_t last_duty_received_micros_ = 0;
   uint32_t last_valid_esc_state_micros_ = 0;
 
-  float mower_duty_ = 0;
+  float mower_duty_ = 0;         // applied duty [-1, 1]; sign = direction, 0 = off
+  float mower_duty_target_ = 0;  // commanded duty; mower_duty_ ramps to it on reversal
+  bool ramping_ = false;         // reversal ramp in progress
+  uint32_t last_ramp_micros_ = 0;
   bool duty_sent_ = false;
   etl::atomic<bool> esc_ever_connected_{false};
   MotorDriver* mower_driver_ = nullptr;


### PR DESCRIPTION
Drives the mow motor from a single signed `Mower Speed` in [-1, 1] (sign = direction, magnitude = duty, 0 = off) and reports the measured RPM signed by the ESC direction, after the redundant `MowerDirection` register was dropped from the protocol (definitions #25, merged).

- Signed speed in, signed RPM out; consumers take `abs()` for magnitude.
- A reversal while the blade is spinning (detected from ESC telemetry) ramps over ~5 s to avoid a current spike; start / stop / same-direction stay instant, and emergency / timeout / ESC-disconnect force an instant 0.
- Bumps the `services` submodule to the merged definitions (`c074039`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct mower speed control for forward and reverse operation.
  - Speed commands are constrained to safe operating limits.
  - Reverse commands transition smoothly while the mower is moving.

- **Bug Fixes**
  - Mower stopping is now immediate when speed reaches zero.
  - Speed and ramping states reset correctly after stops, timeouts, disconnections, and emergencies.
  - Direction changes now respond more reliably to current mower movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->