### PR TITLE
Fix NMEA driver stall on garbage input and cross-read reassembly

### DIFF
--- a/src/drivers/gps/nmea_gps_driver.cpp
+++ b/src/drivers/gps/nmea_gps_driver.cpp
@@ -38,22 +38,31 @@ size_t NmeaGpsDriver::ProcessBytes(const uint8_t *buffer, size_t len) {
         } else {
           error++;
         }
+        len -= bytes_to_take;
+        buffer = newline + 1;
+        line_len = 0;
       } else {
-        // Line would be too long, so throw away the buffer.
+        // Line would be too long. Drop it and skip one byte so we re-sync
+        // on the next dollar symbol instead of discarding valid data after it.
         error++;
+        line_len = 0;
+        buffer++;
+        len--;
       }
-      len -= bytes_to_take;
-      buffer = newline + 1;
-      line_len = 0;
     } else {
       // We will at least need two more characters (newline and null-byte), check if it could fit.
       if (line_len + len + 2 <= sizeof(line)) {
         // Yes, so copy the remaining bytes for next time.
         memcpy(&line[line_len], buffer, len);
+        line_len += len;
         return 1;
       } else {
+        // Line would be too long. Drop it and skip one byte so we make progress
+        // and re-sync on the next dollar symbol.
         error++;
         line_len = 0;
+        buffer++;
+        len--;
       }
     }
   }


### PR DESCRIPTION
## Summary

Two bugs in `NmeaGpsDriver::ProcessBytes`:

- **Stall on garbage input.** When an over-length line had no newline, `line_len` was reset to 0 but `buffer`/`len` were not advanced. If the buffer started with a `$` and contained no `\n`, each loop iteration re-found the same `$`, re-filled past the buffer, reset, and repeated forever — hanging the driver. Now drop a single byte so the parser always makes progress and re-syncs on the next `$` (applied to both over-length branches).

- **Corrupted cross-read reassembly.** When buffering a partial line for the next call, `line_len` was never advanced past the copied bytes. The next chunk overwrote the start of the line, corrupting any sentence split across two reads.