### PR TITLE
Report RPM instead of ERPM and add mower safety RPM cut off

### DIFF
--- a/robots/include/robot.hpp
+++ b/robots/include/robot.hpp
@@ -105,6 +105,19 @@ class Robot {
     (void)baudrate;
     return true;
   }
+
+  /**
+   * @brief Maximum safe mechanical RPM for the mower motor.
+   *
+   * Some robots (e.g. Sabo) can reach dangerous RPMs when the VESC eRPM limit
+   * is not configured. This value defines a firmware-enforced emergency cutoff
+   * that immediately cuts mower power if exceeded.
+   *
+   * @return Mechanical RPM limit, or quiet_NaN() if no limit is needed (default).
+   */
+  virtual float GetMowerMaxSafeRpm() {
+    return std::numeric_limits<float>::quiet_NaN();
+  }
 };
 
 class MowerRobot : public Robot {

--- a/robots/include/sabo_robot.hpp
+++ b/robots/include/sabo_robot.hpp
@@ -88,6 +88,10 @@ class SaboRobot : public MowerRobot {
 
   bool SaveGpsSettings(ProtocolType protocol, uint8_t uart, uint32_t baudrate) override;
 
+  float GetMowerMaxSafeRpm() override {
+    return 3000.0f;  // Stock RPM is 2600. All above 3000 RPM becomes dangerous!
+  }
+
   // ----- Some driver Test* functions used by Boot-Screen -----
 
   bool TestCharger() {

--- a/src/drivers/motor/vesc/VescDriver.cpp
+++ b/src/drivers/motor/vesc/VescDriver.cpp
@@ -100,8 +100,9 @@ void VescDriver::ProcessPayload() {
       break;
     case COMM_GET_MCCONF_TEMP: {
       // message[0..39] = 10× float32_auto fields, message[40] = si_motor_poles
-      // Validate: must be an even number in plausible range (2..20 poles)
+      if (payload_length < 42) break;
       uint8_t raw_poles = message[40];
+      // Validate: must be an even number in plausible range (2..20 poles)
       if (raw_poles >= 2 && raw_poles <= 20 && (raw_poles % 2 == 0)) {
         si_motor_pole_pairs_ = raw_poles / 2;
         mcconf_temp_received_ = true;

--- a/src/drivers/motor/vesc/VescDriver.cpp
+++ b/src/drivers/motor/vesc/VescDriver.cpp
@@ -7,6 +7,7 @@
 #include "buffer.h"
 #include "crc.h"
 #include "datatypes.h"
+#include "ulog.h"
 
 static constexpr uint32_t EVT_ID_RECEIVED = 1;
 static constexpr uint32_t EVT_ID_EXPECT_PACKET = 2;
@@ -79,8 +80,8 @@ void VescDriver::ProcessPayload() {
       index += 4;                      // Skip 4 bytes - mc_interface_read_reset_avg_iq()
       latest_state_.duty_cycle = buffer_get_float16(message, 1000.0,
                                                     &index);  // 2 bytes - mc_interface_get_duty_cycle_now()
-      // mc_interface_get_rpm() returns electrical RPM. Convert to mechanical RPM using motor pole count.
-      latest_state_.rpm = buffer_get_float32(message, 1.0, &index) / (si_motor_poles_ / 2.0f);
+      // mc_interface_get_rpm() returns electrical RPM. Convert to mechanical RPM using motor pole pairs.
+      latest_state_.rpm = buffer_get_float32(message, 1.0, &index) / si_motor_pole_pairs_;
       latest_state_.voltage_input = buffer_get_float16(message, 10.0, &index);  // 2 bytes - GET_INPUT_VOLTAGE()
       index += 4;  // 4 bytes - mc_interface_get_amp_hours(false)
       index += 4;  // 4 bytes - mc_interface_get_amp_hours_charged(false)
@@ -99,8 +100,14 @@ void VescDriver::ProcessPayload() {
       break;
     case COMM_GET_MCCONF_TEMP: {
       // message[0..39] = 10× float32_auto fields, message[40] = si_motor_poles
-      si_motor_poles_ = message[40];
-      mcconf_temp_received_ = true;
+      // Validate: must be an even number in plausible range (2..20 poles)
+      uint8_t raw_poles = message[40];
+      if (raw_poles >= 2 && raw_poles <= 20 && (raw_poles % 2 == 0)) {
+        si_motor_pole_pairs_ = raw_poles / 2;
+        mcconf_temp_received_ = true;
+      } else {
+        ULOG_WARNING("VESC: Invalid pole count %u from ESC (expected 2..20, even). Using default 1 pair.", raw_poles);
+      }
       break;
     }
     default:
@@ -246,6 +253,11 @@ bool VescDriver::Start() {
   if (IsStarted()) {
     return false;
   }
+
+  // Reset pole pair count to default on (re)start, will be updated once COMM_GET_MCCONF_TEMP response arrives.
+  si_motor_pole_pairs_ = 1;
+  mcconf_temp_received_ = false;
+
   bool uartStarted = uartStart(uart_, &uart_config_) == MSG_OK;
   if (!uartStarted) {
     return false;
@@ -288,12 +300,19 @@ bool VescDriver::Start() {
 }
 
 void VescDriver::threadFunc() {
-  // Request motor configuration (pole count) from ESC for correct RPM conversion
-  RequestMcConfTemp();
-
   bool expects_packet = false;
   uint32_t last_ndtr = 0;
+  systime_t last_mcconf_request = 0;
   while (IsStarted()) {
+    // Request motor configuration (pole count) from ESC if we haven't received a valid pole count yet
+    if (!mcconf_temp_received_) {
+      systime_t now = chVTGetSystemTimeX();
+      if (TIME_I2MS(now - last_mcconf_request) >= 1000) {
+        RequestMcConfTemp();
+        last_mcconf_request = now;
+      }
+    }
+
     uint32_t events;
     if (expects_packet) {
       // read with timeout, so that if the packet is too short to fill the whole buffer (and thereby interrupting this),

--- a/src/drivers/motor/vesc/VescDriver.cpp
+++ b/src/drivers/motor/vesc/VescDriver.cpp
@@ -78,8 +78,9 @@ void VescDriver::ProcessPayload() {
       index += 4;                      // Skip 4 bytes - mc_interface_read_reset_avg_id()
       index += 4;                      // Skip 4 bytes - mc_interface_read_reset_avg_iq()
       latest_state_.duty_cycle = buffer_get_float16(message, 1000.0,
-                                                    &index);         // 2 bytes - mc_interface_get_duty_cycle_now()
-      latest_state_.rpm = buffer_get_float32(message, 1.0, &index);  // 4 bytes - mc_interface_get_rpm()
+                                                    &index);  // 2 bytes - mc_interface_get_duty_cycle_now()
+      // mc_interface_get_rpm() returns electrical RPM. Convert to mechanical RPM using motor pole count.
+      latest_state_.rpm = buffer_get_float32(message, 1.0, &index) / (si_motor_poles_ / 2.0f);
       latest_state_.voltage_input = buffer_get_float16(message, 10.0, &index);  // 2 bytes - GET_INPUT_VOLTAGE()
       index += 4;  // 4 bytes - mc_interface_get_amp_hours(false)
       index += 4;  // 4 bytes - mc_interface_get_amp_hours_charged(false)
@@ -96,6 +97,12 @@ void VescDriver::ProcessPayload() {
       index += 4;  // 4 bytes - mc_interface_get_pid_pos_now()
       latest_state_.direction = latest_state_.rpm < 0;
       break;
+    case COMM_GET_MCCONF_TEMP: {
+      // message[0..39] = 10× float32_auto fields, message[40] = si_motor_poles
+      si_motor_poles_ = message[40];
+      mcconf_temp_received_ = true;
+      break;
+    }
     default:
       // ignore
       break;
@@ -193,6 +200,18 @@ void VescDriver::RequestStatus() {
   chMtxUnlock(&mutex_);
 }
 
+void VescDriver::RequestMcConfTemp() {
+  if (IsRawMode()) {
+    return;
+  }
+  chMtxLock(&mutex_);
+  payload_buffer_.payload_length = 1;
+  payload_buffer_.payload[0] = COMM_GET_MCCONF_TEMP;
+  SendPacket();
+  chEvtSignal(processing_thread_, EVT_ID_EXPECT_PACKET);
+  chMtxUnlock(&mutex_);
+}
+
 void VescDriver::SetDuty(float duty) {
   if (IsRawMode()) {
     // ignore when a raw data stream is connected
@@ -269,6 +288,9 @@ bool VescDriver::Start() {
 }
 
 void VescDriver::threadFunc() {
+  // Request motor configuration (pole count) from ESC for correct RPM conversion
+  RequestMcConfTemp();
+
   bool expects_packet = false;
   uint32_t last_ndtr = 0;
   while (IsStarted()) {

--- a/src/drivers/motor/vesc/VescDriver.h
+++ b/src/drivers/motor/vesc/VescDriver.h
@@ -23,6 +23,7 @@ class VescDriver : public DebuggableDriver, public MotorDriver {
 
   bool SetUART(UARTDriver *uart, uint32_t baudrate);
   void RequestStatus() override;
+  void RequestMcConfTemp();
   void SetDuty(float duty) override;
 
   void RawDataInput(uint8_t *data, size_t size) override;
@@ -49,6 +50,11 @@ class VescDriver : public DebuggableDriver, public MotorDriver {
   THD_WORKING_AREA(thd_wa_, 1024){};
   // Milliseconds for automatic status requests. 0 to disable
   uint32_t status_request_millis_ = 0;
+
+  // Motor pole count from ESC config. Default 2 (1 pole pair) = no conversion.
+  uint8_t si_motor_poles_ = 2;
+  // Whether we've received the mcconf_temp from ESC
+  bool mcconf_temp_received_ = false;
 
   // Extend the config struct by a pointer to this instance, so that we can access it in callbacks.
   struct UARTConfigEx : UARTConfig {

--- a/src/drivers/motor/vesc/VescDriver.h
+++ b/src/drivers/motor/vesc/VescDriver.h
@@ -51,8 +51,8 @@ class VescDriver : public DebuggableDriver, public MotorDriver {
   // Milliseconds for automatic status requests. 0 to disable
   uint32_t status_request_millis_ = 0;
 
-  // Motor pole count from ESC config. Default 2 (1 pole pair) = no conversion.
-  uint8_t si_motor_poles_ = 2;
+  // Motor pole pair count from ESC config. Default 1 (2 poles)
+  uint8_t si_motor_pole_pairs_ = 1;
   // Whether we've received the mcconf_temp from ESC
   bool mcconf_temp_received_ = false;
 

--- a/src/services/emergency_service/emergency_service.hpp
+++ b/src/services/emergency_service/emergency_service.hpp
@@ -27,6 +27,8 @@ class EmergencyService : public EmergencyServiceBase {
 
   void RequireService(ServiceExt* svc);
 
+  void UpdateEmergency(uint16_t add, uint16_t clear = 0);
+
  protected:
   void OnStop() override;
   uint32_t OnLoop(uint32_t now_micros, uint32_t last_tick_micros) override;
@@ -40,8 +42,6 @@ class EmergencyService : public EmergencyServiceBase {
                                    XBOT_FUNCTION_FOR_METHOD(EmergencyService, &EmergencyService::SendStatus, this)};
 
   MUTEX_DECL(mtx_);
-
-  void UpdateEmergency(uint16_t add, uint16_t clear = 0);
 
   uint16_t reasons_ = EmergencyReason::TIMEOUT_INPUTS | EmergencyReason::TIMEOUT_HIGH_LEVEL;
   uint32_t last_high_level_emergency_message_ = 0;

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -59,14 +59,9 @@ void MowerService::tick() {
     } else {
       mower_duty_ += (delta > 0.0f) ? max_step : -max_step;
     }
-    duty_sent_ = false;  // force this step out even if a command already sent this tick
   }
 
-  if (!duty_sent_) {
-    // Send motor speed to VESC, if we havent in the meantime
-    // (e.g. due to new value or emergency)
-    SetDuty();
-  }
+  SetDuty();
 
   mower_driver_->RequestStatus();
 
@@ -95,7 +90,6 @@ void MowerService::tick() {
   }
   CommitTransaction();
 
-  duty_sent_ = false;
   chMtxUnlock(&mtx);
 }
 
@@ -124,12 +118,17 @@ void MowerService::ESCCallback(const MotorDriver::ESCState& state) {
 void MowerService::SetDuty() {
   // Get the current emergency state
   bool emergency = emergency_service.GetEmergencyReasons() != 0;
-  if (emergency) {
-    mower_driver_->SetDuty(0);
-  } else {
-    mower_driver_->SetDuty(mower_duty_);
+  float duty_to_send = emergency ? 0.0f : mower_duty_;
+
+  // During emergency, keep sending duty=0 as long as the motor is still
+  // spinning, to ensure the stop command is not lost. Once the motor
+  // actually stops (RPM <= 60), normal dedup logic applies.
+  bool emergency_still_spinning = emergency && std::abs(esc_state_.rpm) > 60.0f;
+
+  if (emergency_still_spinning || duty_to_send != last_sent_duty_) {
+    mower_driver_->SetDuty(duty_to_send);
+    last_sent_duty_ = duty_to_send;
   }
-  duty_sent_ = true;
 }
 
 void MowerService::OnMowerSpeedChanged(const float& new_value) {
@@ -166,7 +165,7 @@ void MowerService::OnMowerSpeedChanged(const float& new_value) {
     mower_duty_ = target;
   }
 
-  if (!ramping_ && !duty_sent_) {
+  if (!ramping_) {
     SetDuty();
   }
   chMtxUnlock(&mtx);

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -120,8 +120,6 @@ void MowerService::SetDuty() {
   bool emergency = emergency_service.GetEmergencyReasons() != 0;
   float duty_to_send = emergency ? 0.0f : mower_duty_;
 
-  ULOG_INFO("SetDuty: sending %.3f (mower_duty=%.3f, emergency=%d, rpm=%.0f)", duty_to_send, mower_duty_, emergency,
-            esc_state_.rpm);
   mower_driver_->SetDuty(duty_to_send);
 }
 

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -126,6 +126,8 @@ void MowerService::SetDuty() {
   bool emergency_still_spinning = emergency && std::abs(esc_state_.rpm) > 60.0f;
 
   if (emergency_still_spinning || duty_to_send != last_sent_duty_) {
+    ULOG_INFO("SetDuty: sending %.3f (mower_duty=%.3f, emergency=%d, spin=%d, rpm=%.0f, last=%.3f)", duty_to_send,
+              mower_duty_, emergency, emergency_still_spinning, esc_state_.rpm, last_sent_duty_);
     mower_driver_->SetDuty(duty_to_send);
     last_sent_duty_ = duty_to_send;
   }

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -14,6 +14,9 @@ void MowerService::OnCreate() {
   mower_driver_->SetStateCallback(
       etl::delegate<void(const MotorDriver::ESCState&)>::create<MowerService, &MowerService::ESCCallback>(*this));
   mower_driver_->Start();
+
+  // Load RPM safety limit from robot configuration
+  mower_max_safe_rpm_ = robot->GetMowerMaxSafeRpm();
 }
 
 bool MowerService::OnStart() {
@@ -102,6 +105,19 @@ void MowerService::ESCCallback(const MotorDriver::ESCState& state) {
   esc_state_valid_ = true;
   esc_ever_connected_ = true;
   last_valid_esc_state_micros_ = xbot::service::system::getTimeMicros();
+
+  // Check RPM safety limit (robot-specific)
+  if (!std::isnan(mower_max_safe_rpm_) && std::abs(state.rpm) > mower_max_safe_rpm_) {
+    ULOG_WARNING("Mower RPM %.0f exceeds safe limit %.0f!", std::abs(state.rpm), mower_max_safe_rpm_);
+    // Cut mower power instantly
+    chMtxLock(&mtx);
+    mower_duty_ = 0;
+    mower_driver_->SetDuty(0);
+    chMtxUnlock(&mtx);
+    // Trigger emergency so the HighLevel/UI sees it
+    emergency_service.UpdateEmergency(EmergencyReason::MOWER_RPM_LIMIT);
+  }
+
   chMtxUnlock(&state_mutex_);
 }
 

--- a/src/services/mower_service/mower_service.cpp
+++ b/src/services/mower_service/mower_service.cpp
@@ -120,17 +120,9 @@ void MowerService::SetDuty() {
   bool emergency = emergency_service.GetEmergencyReasons() != 0;
   float duty_to_send = emergency ? 0.0f : mower_duty_;
 
-  // During emergency, keep sending duty=0 as long as the motor is still
-  // spinning, to ensure the stop command is not lost. Once the motor
-  // actually stops (RPM <= 60), normal dedup logic applies.
-  bool emergency_still_spinning = emergency && std::abs(esc_state_.rpm) > 60.0f;
-
-  if (emergency_still_spinning || duty_to_send != last_sent_duty_) {
-    ULOG_INFO("SetDuty: sending %.3f (mower_duty=%.3f, emergency=%d, spin=%d, rpm=%.0f, last=%.3f)", duty_to_send,
-              mower_duty_, emergency, emergency_still_spinning, esc_state_.rpm, last_sent_duty_);
-    mower_driver_->SetDuty(duty_to_send);
-    last_sent_duty_ = duty_to_send;
-  }
+  ULOG_INFO("SetDuty: sending %.3f (mower_duty=%.3f, emergency=%d, rpm=%.0f)", duty_to_send, mower_duty_, emergency,
+            esc_state_.rpm);
+  mower_driver_->SetDuty(duty_to_send);
 }
 
 void MowerService::OnMowerSpeedChanged(const float& new_value) {

--- a/src/services/mower_service/mower_service.hpp
+++ b/src/services/mower_service/mower_service.hpp
@@ -64,6 +64,9 @@ class MowerService : public MowerServiceBase {
   bool duty_sent_ = false;
   etl::atomic<bool> esc_ever_connected_{false};
   MotorDriver* mower_driver_ = nullptr;
+
+  // RPM safety limit from robot config. NAN = disabled.
+  float mower_max_safe_rpm_ = std::numeric_limits<float>::quiet_NaN();
 };
 
 #endif  // MOWER_SERVICE_HPP

--- a/src/services/mower_service/mower_service.hpp
+++ b/src/services/mower_service/mower_service.hpp
@@ -61,7 +61,7 @@ class MowerService : public MowerServiceBase {
   float mower_duty_target_ = 0;  // commanded duty; mower_duty_ ramps to it on reversal
   bool ramping_ = false;         // reversal ramp in progress
   uint32_t last_ramp_micros_ = 0;
-  bool duty_sent_ = false;
+  float last_sent_duty_ = std::numeric_limits<float>::quiet_NaN();
   etl::atomic<bool> esc_ever_connected_{false};
   MotorDriver* mower_driver_ = nullptr;
 

--- a/src/services/mower_service/mower_service.hpp
+++ b/src/services/mower_service/mower_service.hpp
@@ -61,7 +61,6 @@ class MowerService : public MowerServiceBase {
   float mower_duty_target_ = 0;  // commanded duty; mower_duty_ ramps to it on reversal
   bool ramping_ = false;         // reversal ramp in progress
   uint32_t last_ramp_micros_ = 0;
-  float last_sent_duty_ = std::numeric_limits<float>::quiet_NaN();
   etl::atomic<bool> esc_ever_connected_{false};
   MotorDriver* mower_driver_ = nullptr;
 


### PR DESCRIPTION
- extract motor-poles from COMM_GET_MCCONF_TEMP response
- convert electrical RPM to mechanical RPM in ProcessPayload()
- add RequestMcConfTemp() method and call it at driver startup
- default to 1 pole pair until config is received
- safety motor switch off and emergency in case of RPM increase a (robot specific) safety RPM setting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ESC speed readings now account for the motor’s pole-pair configuration for more accurate mechanical RPM values.
  - Added robot-specific maximum safe mower RPM settings.

- **Bug Fixes**
  - Motor configuration is requested and validated automatically, with safe defaults retained when unavailable or invalid.
  - Excessive mower speed now immediately sets mower duty to zero and raises a safety emergency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->