### PR TITLE
update charge current value for husq310mkii

### DIFF
--- a/robots/include/husq_310mkii_robot.hpp
+++ b/robots/include/husq_310mkii_robot.hpp
@@ -26,7 +26,7 @@ class husq310MKIIRobot : public MowerRobot {
   }
 
   float Power_GetDefaultChargeCurrent() override {
-    return 0.5f;
+    return 1.0f;
   }
 
   float Power_GetAbsoluteMinVoltage() override {
@@ -34,7 +34,7 @@ class husq310MKIIRobot : public MowerRobot {
   }
 
   float Power_GetMaxChargeCurrent() override {
-    return 0.5f;
+    return 1.0f;
   }
 
  private:


### PR DESCRIPTION
Updated charge current to set to 1A rather than 0,5A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default and maximum charging current to 1.0 A, enabling faster charging.
  * Preserved the minimum voltage protection threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->